### PR TITLE
refactor: make environment backend pluggable in workspace exec

### DIFF
--- a/lib/jido_harness/actions/provision_workspace.ex
+++ b/lib/jido_harness/actions/provision_workspace.ex
@@ -6,6 +6,7 @@ defmodule Jido.Harness.Actions.ProvisionWorkspace do
     description: "Provision harness workspace",
     schema: [
       workspace_id: [type: :string, required: true],
+      environment: [type: :atom, required: false],
       opts: [type: :map, default: %{}]
     ]
 
@@ -16,6 +17,7 @@ defmodule Jido.Harness.Actions.ProvisionWorkspace do
   @impl true
   def run(params, _context) do
     with {:ok, opts} <- Helpers.to_keyword(params.opts || %{}) do
+      opts = maybe_put_environment(opts, Map.get(params, :environment))
       Workspace.provision_workspace(params.workspace_id, opts)
     else
       {:error, {:invalid_option_key, key}} ->
@@ -25,4 +27,7 @@ defmodule Jido.Harness.Actions.ProvisionWorkspace do
         {:error, Error.invalid("opts must be a map or keyword list", %{field: :opts})}
     end
   end
+
+  defp maybe_put_environment(opts, nil), do: opts
+  defp maybe_put_environment(opts, env) when is_atom(env), do: Keyword.put(opts, :environment, env)
 end

--- a/lib/jido_harness/actions/teardown_workspace.ex
+++ b/lib/jido_harness/actions/teardown_workspace.ex
@@ -6,6 +6,7 @@ defmodule Jido.Harness.Actions.TeardownWorkspace do
     description: "Teardown harness workspace",
     schema: [
       session_id: [type: :string, required: true],
+      environment: [type: :atom, required: false],
       opts: [type: :map, default: %{}]
     ]
 
@@ -16,6 +17,7 @@ defmodule Jido.Harness.Actions.TeardownWorkspace do
   @impl true
   def run(params, _context) do
     with {:ok, opts} <- Helpers.to_keyword(params.opts || %{}) do
+      opts = maybe_put_environment(opts, Map.get(params, :environment))
       {:ok, Workspace.teardown_workspace(params.session_id, opts)}
     else
       {:error, {:invalid_option_key, key}} ->
@@ -25,4 +27,7 @@ defmodule Jido.Harness.Actions.TeardownWorkspace do
         {:error, Error.invalid("opts must be a map or keyword list", %{field: :opts})}
     end
   end
+
+  defp maybe_put_environment(opts, nil), do: opts
+  defp maybe_put_environment(opts, env) when is_atom(env), do: Keyword.put(opts, :environment, env)
 end

--- a/lib/jido_harness/exec/workspace.ex
+++ b/lib/jido_harness/exec/workspace.ex
@@ -1,42 +1,48 @@
 defmodule Jido.Harness.Exec.Workspace do
   @moduledoc """
-  Workspace lifecycle helpers backed by `Jido.Shell.SpriteLifecycle`.
+  Workspace lifecycle helpers with pluggable environment backends.
+
+  By default uses `Jido.Shell.Environment.Sprite` (Fly.io Sprites).
+  Pass `environment: MyEnvironment` in opts to use a different provider.
   """
 
   alias Jido.Harness.Exec.Error
-  alias Jido.Shell.SpriteLifecycle
+
+  @default_environment Jido.Shell.Environment.Sprite
 
   @doc """
-  Provisions a sprite-backed workspace/session for harness execution.
+  Provisions a workspace/session for harness execution.
+
+  ## Options
+
+  - `:environment` — module implementing `Jido.Shell.Environment` (default: `Environment.Sprite`)
+  - `:config` — environment-specific configuration map (also accepts legacy `:sprite_config`)
+  - All other options are passed through to the environment's `provision/3`
   """
   @spec provision_workspace(String.t(), keyword()) :: {:ok, map()} | {:error, term()}
   def provision_workspace(workspace_id, opts \\ [])
       when is_binary(workspace_id) and is_list(opts) do
-    sprite_config = Keyword.get(opts, :sprite_config, %{})
-    timeout = Keyword.get(opts, :timeout, 30_000)
-    workspace_dir = Keyword.get(opts, :workspace_dir)
-    sprite_name = Keyword.get(opts, :sprite_name)
-    session_mod = Keyword.get(opts, :session_mod, Jido.Shell.ShellSession)
-    agent_mod = Keyword.get(opts, :agent_mod, Jido.Shell.Agent)
+    environment = Keyword.get(opts, :environment, @default_environment)
+    config = Keyword.get(opts, :sprite_config, Keyword.get(opts, :config, %{}))
 
-    if map_size(sprite_config) == 0 do
-      {:error, Error.invalid("sprite_config is required for workspace provisioning", %{field: :sprite_config})}
+    if map_size(config) == 0 do
+      {:error, Error.invalid("config is required for workspace provisioning", %{field: :config})}
     else
-      SpriteLifecycle.provision(workspace_id, sprite_config,
-        timeout: timeout,
-        workspace_dir: workspace_dir,
-        sprite_name: sprite_name,
-        session_mod: session_mod,
-        agent_mod: agent_mod
-      )
+      environment.provision(workspace_id, config, opts)
     end
   end
 
   @doc """
-  Tears down a provisioned sprite/session and returns teardown metadata.
+  Tears down a provisioned workspace/session and returns teardown metadata.
+
+  ## Options
+
+  - `:environment` — module implementing `Jido.Shell.Environment` (default: `Environment.Sprite`)
+  - All other options are passed through to the environment's `teardown/2`
   """
   @spec teardown_workspace(String.t(), keyword()) :: map()
   def teardown_workspace(session_id, opts \\ []) when is_binary(session_id) and is_list(opts) do
-    SpriteLifecycle.teardown(session_id, opts)
+    environment = Keyword.get(opts, :environment, @default_environment)
+    environment.teardown(session_id, opts)
   end
 end


### PR DESCRIPTION
## Summary
- Accept `:environment` parameter in `ProvisionWorkspace` and `TeardownWorkspace` actions
- Replace hardcoded `SpriteLifecycle` with configurable environment module in `Workspace`
- Default to `Jido.Shell.Environment.Sprite` for backward compatibility
- Zero remaining references to `SpriteLifecycle`, `SpriteClient`, or `SpriteSession`

## Test plan
- [x] 58 tests pass, 0 failures
- [x] Compiles clean with `--warnings-as-errors`
- [x] Backward compatible — existing callers without `:environment` param use Sprite default