### PR TITLE
ci: roll out shared github-actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,46 +6,18 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    name: Lint
+    uses: agentjido/github-actions/.github/workflows/elixir-lint.yml@main
+    with:
+      otp_version: "27.2"
+      elixir_version: "1.18.4"
+      validate_hex_package: false
+
   test:
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        otp: ["27.2"]
-        elixir: ["1.18.4"]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Elixir
-        uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{ matrix.otp }}
-          elixir-version: ${{ matrix.elixir }}
-
-      - name: Restore deps cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            deps
-            _build
-          key: ${{ runner.os }}-mix-${{ hashFiles('mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-mix-
-
-      - name: Install dependencies
-        run: mix deps.get
-
-      - name: Compile
-        run: mix compile --warnings-as-errors
-
-      - name: Test
-        run: mix test
-
-      - name: Credo
-        run: mix credo --min-priority higher
-
-      - name: Doctor
-        run: mix doctor --raise
+    name: Test
+    uses: agentjido/github-actions/.github/workflows/elixir-test.yml@main
+    with:
+      otp_versions: '["27.2"]'
+      elixir_versions: '["1.18.4"]'
+      test_command: mix test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,33 +1,35 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (no git push, no tag, no GitHub release, no Hex publish)"
+        required: false
+        type: boolean
+        default: false
+      hex_dry_run:
+        description: "Hex dry run only (run all git/release steps, but skip actual Hex publish)"
+        required: false
+        type: boolean
+        default: false
+      skip_tests:
+        description: "Skip tests before release"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Elixir
-        uses: erlef/setup-beam@v1
-        with:
-          otp-version: "27.2"
-          elixir-version: "1.18.4"
-
-      - name: Install dependencies
-        run: mix deps.get
-
-      - name: Run tests
-        run: mix test
-
-      - name: Publish to Hex
-        if: startsWith(github.ref, 'refs/tags/v')
-        env:
-          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
-        run: mix hex.publish --yes
+  release:
+    name: Release
+    uses: agentjido/github-actions/.github/workflows/elixir-release.yml@main
+    with:
+      otp_version: "27.2"
+      elixir_version: "1.18.4"
+      dry_run: ${{ inputs.dry_run }}
+      hex_dry_run: ${{ inputs.hex_dry_run }}
+      skip_tests: ${{ inputs.skip_tests }}
+    secrets: inherit

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,4 +4,34 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:module]
 
+if config_env() == :dev do
+  config :git_hooks,
+    auto_install: true,
+    verbose: true,
+    hooks: [
+      commit_msg: [
+        tasks: [
+          {:cmd, "mix git_ops.check_message", include_hook_args: true}
+        ]
+      ]
+    ]
+
+  config :git_ops,
+    mix_project: Jido.Harness.MixProject,
+    changelog_file: "CHANGELOG.md",
+    repository_url: "https://github.com/agentjido/jido_harness",
+    manage_mix_version?: true,
+    version_tag_prefix: "v",
+    types: [
+      feat: [header: "Features"],
+      fix: [header: "Bug Fixes"],
+      perf: [header: "Performance"],
+      refactor: [header: "Refactoring"],
+      docs: [hidden?: true],
+      test: [hidden?: true],
+      chore: [hidden?: true],
+      ci: [hidden?: true]
+    ]
+end
+
 import_config "#{config_env()}.exs"


### PR DESCRIPTION
## Summary
- move the repo onto the shared `agentjido/github-actions` lint and test workflows
- move release automation onto the shared git_ops-based release workflow
- add the minimal `git_ops` configuration needed for the shared release flow where this repo did not already have it

## Notes
- repo-specific extra jobs were only kept where they are part of the current CI contract
- this rollout intentionally avoids the known edge-case repos (`llm_db`, `jido_run`, browser/shell special cases, and the no-workflow repos)
