### PR TITLE
ci: pin shared github-actions workflows to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   lint:
     name: Lint
-    uses: agentjido/github-actions/.github/workflows/elixir-lint.yml@main
+    uses: agentjido/github-actions/.github/workflows/elixir-lint.yml@v3
     with:
       otp_version: "27.2"
       elixir_version: "1.18.4"
@@ -16,7 +16,7 @@ jobs:
 
   test:
     name: Test
-    uses: agentjido/github-actions/.github/workflows/elixir-test.yml@main
+    uses: agentjido/github-actions/.github/workflows/elixir-test.yml@v3
     with:
       otp_versions: '["27.2"]'
       elixir_versions: '["1.18.4"]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   release:
     name: Release
-    uses: agentjido/github-actions/.github/workflows/elixir-release.yml@main
+    uses: agentjido/github-actions/.github/workflows/elixir-release.yml@v3
     with:
       otp_version: "27.2"
       elixir_version: "1.18.4"


### PR DESCRIPTION
## Summary
- pin shared reusable GitHub workflow references to `@v3`
- align this repo with the workspace rollout target
- keep the workflow shape otherwise unchanged

## Testing
- not run (`.github/workflows/*` only)
