### PR TITLE
docs: lock adapter contract and GitHub dependency phase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "mix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "elixir"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "deps"
+      include: "scope"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,29 @@
 name: CI
 
 on:
-  push:
-    branches: ["main", "master"]
   pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
     name: Lint
     uses: agentjido/github-actions/.github/workflows/elixir-lint.yml@v3
     with:
-      otp_version: "27.2"
-      elixir_version: "1.18.4"
       validate_hex_package: false
 
   test:
     name: Test
     uses: agentjido/github-actions/.github/workflows/elixir-test.yml@v3
     with:
-      otp_versions: '["27.2"]'
-      elixir_versions: '["1.18.4"]'
+      otp_versions: '["27", "28"]'
+      elixir_versions: '["1.18", "1.19"]'
+      experimental_compile_elixir_versions: '["v1.20.0-rc.4"]'
+      experimental_compile_otp_versions: '["28.4.1"]'
+      experimental_compile_otp_name: "28"
       test_command: mix test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: false
+      version_override:
+        description: "Optional bare SemVer override (for example 1.2.3, not v1.2.3)"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -27,9 +32,8 @@ jobs:
     name: Release
     uses: agentjido/github-actions/.github/workflows/elixir-release.yml@v3
     with:
-      otp_version: "27.2"
-      elixir_version: "1.18.4"
       dry_run: ${{ inputs.dry_run }}
       hex_dry_run: ${{ inputs.hex_dry_run }}
       skip_tests: ${{ inputs.skip_tests }}
+      version_override: ${{ inputs.version_override }}
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ Add `jido_harness` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:jido_harness, "~> 0.1.0"}
+    {:jido_harness, github: "agentjido/jido_harness", branch: "main", override: true}
   ]
 end
 ```
+
+The adapter packages are currently being aligned as a GitHub-based repo set, so sibling adapters should use GitHub dependencies in this phase as well.
 
 ## Usage
 
@@ -69,7 +71,9 @@ Jido.Harness.cancel(:codex, "session_id")
 
 ## Documentation
 
-Full documentation is available at [https://hexdocs.pm/jido_harness](https://hexdocs.pm/jido_harness).
+- [`docs/adapter_contract.md`](docs/adapter_contract.md) for the shared adapter checklist
+- [`docs/dependency_policy.md`](docs/dependency_policy.md) for the current dependency policy
+- `mix docs` to build local package docs during this GitHub-dependency phase
 
 ## Package Purpose
 

--- a/docs/adapter_contract.md
+++ b/docs/adapter_contract.md
@@ -1,0 +1,88 @@
+# Adapter Contract
+
+This checklist defines the stable surface that `jido_harness` expects from every adapter package in the current ecosystem phase.
+
+## Required Callbacks
+
+Every adapter must implement:
+
+- `id/0`
+- `capabilities/0`
+- `run/2`
+- `runtime_contract/0`
+
+`cancel/1` is optional, but only optional when the adapter reports `cancellation?: false`.
+
+## `id/0`
+
+- returns the provider atom used by the harness registry
+- must match `runtime_contract().provider`
+
+Examples:
+
+- `:codex`
+- `:amp`
+- `:claude`
+- `:gemini`
+- `:opencode`
+
+## `capabilities/0`
+
+Adapters must return `%Jido.Harness.Capabilities{}` with explicit booleans for all flags.
+
+Current flag meanings:
+
+- `streaming?`: `run/2` emits incremental events instead of only terminal output
+- `tool_calls?`: adapter emits normalized `:tool_call` events
+- `tool_results?`: adapter emits normalized `:tool_result` events
+- `thinking?`: adapter emits normalized thinking/reasoning events
+- `resume?`: adapter can resume a previous session/thread
+- `usage?`: adapter emits canonical `:usage` events
+- `file_changes?`: adapter emits normalized file-change events
+- `cancellation?`: adapter exposes `cancel/1` for active sessions
+
+These flags are declarative contract metadata. They are not marketing claims. If a capability is incomplete or conditional, keep it `false` until the emitted behavior is stable.
+
+## `run/2`
+
+- accepts `%Jido.Harness.RunRequest{}`
+- returns `{:ok, enumerable}` or `{:error, reason}`
+- emits `%Jido.Harness.Event{}` values only
+- uses provider-specific metadata from `request.metadata`
+- returns structured validation/config/execution errors on adapter-facing failures
+
+## `runtime_contract/0`
+
+Adapters must return `%Jido.Harness.RuntimeContract{}` with:
+
+- provider id
+- required host env vars
+- forwarded/injected runtime env vars
+- required runtime tools
+- compatibility probes
+- install steps
+- auth bootstrap steps
+- `triage_command_template`
+- `coding_command_template`
+- `success_markers`
+
+## Command Template Semantics
+
+Templates must be non-empty and use one of the canonical placeholders:
+
+- `{{prompt}}` for inline prompt substitution
+- `{{prompt_file}}` for prompt-file substitution
+
+The harness runtime layer expands these placeholders when building commands. Adapters should not invent package-specific placeholder names.
+
+## Success Marker Semantics
+
+`success_markers` must be a non-empty list of maps with string keys.
+
+These markers define what the harness runtime should treat as terminal success when evaluating streamed or runtime-mediated execution. They should match real adapter output, not best-effort guesses.
+
+## Error Shape
+
+Adapter-facing validation/config/execution failures should be returned as structured error structs, not raw tuples, whenever the adapter is rejecting input or surfacing a known adapter/runtime failure mode.
+
+Internal SDK/library tuples may still exist below the adapter boundary, but `run/2` and related public adapter entry points should normalize them before they escape.

--- a/docs/dependency_policy.md
+++ b/docs/dependency_policy.md
@@ -2,6 +2,16 @@
 
 This policy governs `jido_harness` and sibling provider/runtime packages during consolidation.
 
+## Current Phase
+
+For the current adapter-alignment phase:
+
+- use GitHub dependencies for the Jido harness packages
+- keep the same branch-based dependency policy across the adapter repos
+- do not treat Hex packaging as an active delivery target yet
+
+This policy should remain in place until the adapter contract and CI baselines are aligned across the repo set.
+
 ## Baseline Versions
 
 - Elixir: `~> 1.18`

--- a/lib/jido_harness.ex
+++ b/lib/jido_harness.ex
@@ -227,9 +227,10 @@ defmodule Jido.Harness do
     "#{id} (#{module_name})"
   end
 
-  defp docs_url_for(:amp), do: "https://hex.pm/packages/jido_amp"
-  defp docs_url_for(:claude), do: "https://hex.pm/packages/jido_claude"
-  defp docs_url_for(:codex), do: "https://hex.pm/packages/jido_codex"
-  defp docs_url_for(:gemini), do: "https://hex.pm/packages/jido_gemini"
+  defp docs_url_for(:amp), do: "https://github.com/agentjido/jido_amp"
+  defp docs_url_for(:claude), do: "https://github.com/agentjido/jido_claude"
+  defp docs_url_for(:codex), do: "https://github.com/agentjido/jido_codex"
+  defp docs_url_for(:gemini), do: "https://github.com/agentjido/jido_gemini"
+  defp docs_url_for(:opencode), do: "https://github.com/agentjido/jido_opencode"
   defp docs_url_for(_), do: nil
 end

--- a/lib/jido_harness/adapter_contract.ex
+++ b/lib/jido_harness/adapter_contract.ex
@@ -2,6 +2,15 @@ defmodule Jido.Harness.AdapterContract do
   @moduledoc """
   Shared contract tests for provider adapter packages.
 
+  The checklist enforced here is intentionally small and stable:
+
+  - `id/0` returns the provider atom
+  - `capabilities/0` returns `Jido.Harness.Capabilities`
+  - `runtime_contract/0` returns a complete `Jido.Harness.RuntimeContract`
+  - runtime command templates use canonical `{{prompt}}` or `{{prompt_file}}` placeholders
+  - `success_markers` are non-empty maps
+  - adapters that advertise `cancellation?: true` expose `cancel/1`
+
   ## Usage
 
       defmodule MyAdapterTest do
@@ -43,6 +52,16 @@ defmodule Jido.Harness.AdapterContract do
 
       defp __adapter_contract_resolve_module__(value) when is_atom(value), do: value
 
+      defp __adapter_contract_valid_template__(template) when is_binary(template) do
+        trimmed = String.trim(template)
+
+        trimmed != "" and
+          (String.contains?(trimmed, "{{prompt}}") or
+             String.contains?(trimmed, "{{prompt_file}}"))
+      end
+
+      defp __adapter_contract_valid_template__(_), do: false
+
       test "adapter contract: id/0 returns atom" do
         adapter = __adapter_contract_resolve_module__(@adapter_contract_adapter)
         assert Code.ensure_loaded?(adapter), "adapter module could not be loaded: #{inspect(adapter)}"
@@ -77,6 +96,16 @@ defmodule Jido.Harness.AdapterContract do
         end
       end
 
+      test "adapter contract: cancellation capability matches cancel/1 support" do
+        adapter = __adapter_contract_resolve_module__(@adapter_contract_adapter)
+        caps = adapter.capabilities()
+
+        if caps.cancellation? do
+          assert function_exported?(adapter, :cancel, 1),
+                 "adapter declares cancellation?: true but does not export cancel/1"
+        end
+      end
+
       test "adapter contract: runtime_contract/0 is complete" do
         adapter = __adapter_contract_resolve_module__(@adapter_contract_adapter)
         assert Code.ensure_loaded?(adapter)
@@ -84,13 +113,20 @@ defmodule Jido.Harness.AdapterContract do
         contract = apply(adapter, :runtime_contract, [])
         assert %RuntimeContract{} = contract
         assert is_atom(contract.provider)
+        assert contract.provider == adapter.id()
         assert is_list(contract.runtime_tools_required)
         assert is_list(contract.compatibility_probes)
         assert is_list(contract.install_steps)
         assert is_list(contract.auth_bootstrap_steps)
-        assert is_binary(contract.triage_command_template)
-        assert is_binary(contract.coding_command_template)
+        assert __adapter_contract_valid_template__(contract.triage_command_template)
+        assert __adapter_contract_valid_template__(contract.coding_command_template)
         assert is_list(contract.success_markers)
+
+        assert Enum.all?(contract.success_markers, fn marker ->
+                 is_map(marker) and map_size(marker) > 0 and
+                   Enum.all?(Map.keys(marker), &is_binary/1)
+               end),
+               "success_markers must contain non-empty maps with string keys"
       end
 
       if check_run do

--- a/mix.exs
+++ b/mix.exs
@@ -24,6 +24,7 @@ defmodule Jido.Harness.MixProject do
           "README.md",
           "CHANGELOG.md",
           "CONTRIBUTING.md",
+          "docs/adapter_contract.md",
           "docs/telemetry.md",
           "docs/dependency_policy.md"
         ],

--- a/test/support/stubs_helper.exs
+++ b/test/support/stubs_helper.exs
@@ -17,7 +17,7 @@ defmodule Jido.Harness.Test.RuntimeContractStub do
       auth_bootstrap_steps: [],
       triage_command_template: "runtime --triage {{prompt}}",
       coding_command_template: "runtime --coding {{prompt}}",
-      success_markers: []
+      success_markers: [%{"type" => "result", "subtype" => "success"}]
     })
   end
 end


### PR DESCRIPTION
## Summary
- add an explicit adapter contract checklist to the harness docs and ExUnit contract helper
- tighten contract expectations around provider/runtime alignment, template placeholders, success markers, and cancellation semantics
- update harness-facing docs/links to reflect the current GitHub-dependency phase instead of implying Hex-first installation

## Validation
- mix test