### PR TITLE
refactor: make environment backend pluggable in workspace exec

### DIFF
--- a/lib/jido_harness/actions/provision_workspace.ex
+++ b/lib/jido_harness/actions/provision_workspace.ex
@@ -6,6 +6,7 @@ defmodule Jido.Harness.Actions.ProvisionWorkspace do
     description: "Provision harness workspace",
     schema: [
       workspace_id: [type: :string, required: true],
+      environment: [type: :atom, required: false],
       opts: [type: :map, default: %{}]
     ]
 
@@ -16,6 +17,7 @@ defmodule Jido.Harness.Actions.ProvisionWorkspace do
   @impl true
   def run(params, _context) do
     with {:ok, opts} <- Helpers.to_keyword(params.opts || %{}) do
+      opts = maybe_put_environment(opts, Map.get(params, :environment))
       Workspace.provision_workspace(params.workspace_id, opts)
     else
       {:error, {:invalid_option_key, key}} ->
@@ -25,4 +27,7 @@ defmodule Jido.Harness.Actions.ProvisionWorkspace do
         {:error, Error.invalid("opts must be a map or keyword list", %{field: :opts})}
     end
   end
+
+  defp maybe_put_environment(opts, nil), do: opts
+  defp maybe_put_environment(opts, env) when is_atom(env), do: Keyword.put(opts, :environment, env)
 end

--- a/lib/jido_harness/actions/teardown_workspace.ex
+++ b/lib/jido_harness/actions/teardown_workspace.ex
@@ -6,6 +6,7 @@ defmodule Jido.Harness.Actions.TeardownWorkspace do
     description: "Teardown harness workspace",
     schema: [
       session_id: [type: :string, required: true],
+      environment: [type: :atom, required: false],
       opts: [type: :map, default: %{}]
     ]
 
@@ -16,6 +17,7 @@ defmodule Jido.Harness.Actions.TeardownWorkspace do
   @impl true
   def run(params, _context) do
     with {:ok, opts} <- Helpers.to_keyword(params.opts || %{}) do
+      opts = maybe_put_environment(opts, Map.get(params, :environment))
       {:ok, Workspace.teardown_workspace(params.session_id, opts)}
     else
       {:error, {:invalid_option_key, key}} ->
@@ -25,4 +27,7 @@ defmodule Jido.Harness.Actions.TeardownWorkspace do
         {:error, Error.invalid("opts must be a map or keyword list", %{field: :opts})}
     end
   end
+
+  defp maybe_put_environment(opts, nil), do: opts
+  defp maybe_put_environment(opts, env) when is_atom(env), do: Keyword.put(opts, :environment, env)
 end

--- a/lib/jido_harness/exec/workspace.ex
+++ b/lib/jido_harness/exec/workspace.ex
@@ -1,42 +1,49 @@
 defmodule Jido.Harness.Exec.Workspace do
   @moduledoc """
-  Workspace lifecycle helpers backed by `Jido.Shell.Environment.Sprite`.
+  Workspace lifecycle helpers with pluggable environment backends.
+
+  By default, workspace lifecycle operations use `Jido.Shell.Environment.Sprite`.
+  Pass `environment: MyEnvironment` in opts to use a different provider.
   """
 
   alias Jido.Harness.Exec.Error
-  alias Jido.Shell.Environment.Sprite, as: SpriteLifecycle
+
+  @default_environment Jido.Shell.Environment.Sprite
 
   @doc """
-  Provisions a sprite-backed workspace/session for harness execution.
+  Provisions a workspace/session for harness execution.
+
+  ## Options
+
+  - `:environment` - module implementing `Jido.Shell.Environment`
+  - `:config` - environment-specific configuration map
+  - `:sprite_config` - legacy alias for Sprite configuration
+  - all other options are passed through to the environment's `provision/3`
   """
   @spec provision_workspace(String.t(), keyword()) :: {:ok, map()} | {:error, term()}
   def provision_workspace(workspace_id, opts \\ [])
       when is_binary(workspace_id) and is_list(opts) do
-    sprite_config = Keyword.get(opts, :sprite_config, %{})
-    timeout = Keyword.get(opts, :timeout, 30_000)
-    workspace_dir = Keyword.get(opts, :workspace_dir)
-    sprite_name = Keyword.get(opts, :sprite_name)
-    session_mod = Keyword.get(opts, :session_mod, Jido.Shell.ShellSession)
-    agent_mod = Keyword.get(opts, :agent_mod, Jido.Shell.Agent)
+    environment = Keyword.get(opts, :environment, @default_environment)
+    config = Keyword.get(opts, :sprite_config, Keyword.get(opts, :config, %{}))
 
-    if map_size(sprite_config) == 0 do
-      {:error, Error.invalid("sprite_config is required for workspace provisioning", %{field: :sprite_config})}
+    if map_size(config) == 0 do
+      {:error, Error.invalid("config is required for workspace provisioning", %{field: :config})}
     else
-      SpriteLifecycle.provision(workspace_id, sprite_config,
-        timeout: timeout,
-        workspace_dir: workspace_dir,
-        sprite_name: sprite_name,
-        session_mod: session_mod,
-        agent_mod: agent_mod
-      )
+      environment.provision(workspace_id, config, opts)
     end
   end
 
   @doc """
-  Tears down a provisioned sprite/session and returns teardown metadata.
+  Tears down a provisioned workspace/session and returns teardown metadata.
+
+  ## Options
+
+  - `:environment` - module implementing `Jido.Shell.Environment`
+  - all other options are passed through to the environment's `teardown/2`
   """
   @spec teardown_workspace(String.t(), keyword()) :: map()
   def teardown_workspace(session_id, opts \\ []) when is_binary(session_id) and is_list(opts) do
-    SpriteLifecycle.teardown(session_id, opts)
+    environment = Keyword.get(opts, :environment, @default_environment)
+    environment.teardown(session_id, opts)
   end
 end

--- a/test/jido_harness/workspace_test.exs
+++ b/test/jido_harness/workspace_test.exs
@@ -1,0 +1,107 @@
+defmodule Jido.Harness.WorkspaceTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Harness.Actions.{ProvisionWorkspace, TeardownWorkspace}
+  alias Jido.Harness.Exec.Workspace
+
+  defmodule EnvironmentStub do
+    @behaviour Jido.Shell.Environment
+
+    @impl true
+    def provision(workspace_id, config, opts) do
+      {:ok,
+       %{
+         workspace_id: workspace_id,
+         session_id: "session-#{workspace_id}",
+         workspace_dir: Map.get(config, :workspace_dir, "/work/#{workspace_id}"),
+         config: config,
+         opts: opts
+       }}
+    end
+
+    @impl true
+    def teardown(session_id, opts) do
+      %{
+        teardown_verified: true,
+        teardown_attempts: 1,
+        warnings: nil,
+        session_id: session_id,
+        opts: opts
+      }
+    end
+  end
+
+  describe "provision_workspace/2" do
+    test "uses a custom environment backend" do
+      assert {:ok, result} =
+               Workspace.provision_workspace("workspace-1",
+                 environment: EnvironmentStub,
+                 config: %{workspace_dir: "/tmp/workspace-1"},
+                 marker: :kept
+               )
+
+      assert result.session_id == "session-workspace-1"
+      assert result.workspace_dir == "/tmp/workspace-1"
+      assert result.config == %{workspace_dir: "/tmp/workspace-1"}
+      assert result.opts[:environment] == EnvironmentStub
+      assert result.opts[:marker] == :kept
+    end
+
+    test "accepts sprite_config as the legacy config option" do
+      assert {:ok, result} =
+               Workspace.provision_workspace("workspace-2",
+                 environment: EnvironmentStub,
+                 sprite_config: %{workspace_dir: "/tmp/workspace-2"}
+               )
+
+      assert result.config == %{workspace_dir: "/tmp/workspace-2"}
+    end
+
+    test "returns a harness error when config is missing" do
+      assert {:error, error} =
+               Workspace.provision_workspace("workspace-3", environment: EnvironmentStub)
+
+      assert error.field == :config
+      assert Exception.message(error) == "config is required for workspace provisioning"
+    end
+  end
+
+  describe "teardown_workspace/2" do
+    test "uses a custom environment backend" do
+      result = Workspace.teardown_workspace("session-1", environment: EnvironmentStub, marker: :kept)
+
+      assert result.teardown_verified
+      assert result.session_id == "session-1"
+      assert result.opts[:environment] == EnvironmentStub
+      assert result.opts[:marker] == :kept
+    end
+  end
+
+  describe "workspace actions" do
+    test "provision action forwards top-level environment into opts" do
+      assert {:ok, result} =
+               ProvisionWorkspace.run(
+                 %{
+                   workspace_id: "workspace-4",
+                   environment: EnvironmentStub,
+                   opts: %{config: %{workspace_dir: "/tmp/workspace-4"}}
+                 },
+                 %{}
+               )
+
+      assert result.opts[:environment] == EnvironmentStub
+      assert result.config == %{workspace_dir: "/tmp/workspace-4"}
+    end
+
+    test "teardown action forwards top-level environment into opts" do
+      assert {:ok, result} =
+               TeardownWorkspace.run(
+                 %{session_id: "session-2", environment: EnvironmentStub, opts: %{}},
+                 %{}
+               )
+
+      assert result.teardown_verified
+      assert result.opts[:environment] == EnvironmentStub
+    end
+  end
+end


### PR DESCRIPTION
Supersedes #1 with the same pluggable environment direction, rebased onto current main and cleaned up from review.

Changes:
- add an optional `environment` parameter to workspace provision/teardown actions
- route workspace lifecycle calls through a `Jido.Shell.Environment` implementation
- preserve Sprite as the default backend and keep `sprite_config` compatibility
- add unit coverage for custom backends, action forwarding, and missing config handling

Validation:
- `mix test`

Credit to @patrickdet for the original PR.