### PR TITLE
fix: require jido 2.2 dependency floor

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -106,7 +106,7 @@ defmodule Jido.Harness.MixProject do
       {:zoi, "~> 0.17"},
       {:splode, "~> 0.3.0"},
       {:jason, "~> 1.4"},
-      {:jido, "~> 2.1"},
+      {:jido, "~> 2.2"},
       {:jido_shell, github: "agentjido/jido_shell", branch: "main", override: true},
       {:sprites, git: "https://github.com/mikehostetler/sprites-ex.git", override: true},
 


### PR DESCRIPTION
## Summary
- Raise the runtime Jido dependency floor to ~> 2.2
- Document that this ensures consumers resolve the jido_signal line that supports signal extension_policy declarations

## Verification
- mix test
- mix quality

## Notes
- Current Hex jido_action 2.2.1 still emits Graph.* warnings against multigraph 0.16.1-mg.3. The source migration to Multigraph exists on jido_action main but needs the next Hex release for downstream clean compiles.