### PR TITLE
feat: add RunRequest session_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Optional `session_id` field on `Jido.Harness.RunRequest` so callers can pass
+  a provider-neutral resume/session hint through the harness API.
 - Expanded `Jido.Harness` facade into a multi-provider wrapper layer:
   - `run/2` (default provider dispatch)
   - `run_request/2` and `run_request/3`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ config :jido_harness, :default_provider, :codex
 # Run with explicit provider
 {:ok, events} = Jido.Harness.run(:codex, "fix the bug", cwd: "/my/project")
 
+# Resume a provider session when the adapter supports it
+{:ok, events} = Jido.Harness.run(:codex, "continue", session_id: "thread_or_session_id")
+
 # Or run through the default provider
 {:ok, events} = Jido.Harness.run("fix the bug", cwd: "/my/project")
 ```

--- a/docs/adapter_contract.md
+++ b/docs/adapter_contract.md
@@ -48,6 +48,8 @@ These flags are declarative contract metadata. They are not marketing claims. If
 - accepts `%Jido.Harness.RunRequest{}`
 - returns `{:ok, enumerable}` or `{:error, reason}`
 - emits `%Jido.Harness.Event{}` values only
+- treats `request.session_id` as the provider-neutral resume/session hint when
+  `capabilities().resume?` is true
 - uses provider-specific metadata from `request.metadata`
 - returns structured validation/config/execution errors on adapter-facing failures
 

--- a/lib/jido_harness.ex
+++ b/lib/jido_harness.ex
@@ -22,6 +22,7 @@ defmodule Jido.Harness do
     :system_prompt,
     :allowed_tools,
     :attachments,
+    :session_id,
     :metadata
   ]
 

--- a/lib/jido_harness/run_request.ex
+++ b/lib/jido_harness/run_request.ex
@@ -14,6 +14,7 @@ defmodule Jido.Harness.RunRequest do
               system_prompt: Zoi.string() |> Zoi.nullish(),
               allowed_tools: Zoi.array(Zoi.string()) |> Zoi.nullish(),
               attachments: Zoi.array(Zoi.string()) |> Zoi.default([]),
+              session_id: Zoi.string() |> Zoi.nullish(),
               metadata: Zoi.map(Zoi.string(), Zoi.any()) |> Zoi.default(%{})
             },
             coerce: true

--- a/test/jido_harness/schema_test.exs
+++ b/test/jido_harness/schema_test.exs
@@ -5,8 +5,11 @@ defmodule Jido.Harness.SchemaTest do
 
   test "run_request schema constructors validate inputs" do
     assert is_struct(RunRequest.schema())
-    assert {:ok, %RunRequest{prompt: "hello"}} = RunRequest.new(%{prompt: "hello"})
-    assert %RunRequest{prompt: "hello"} = RunRequest.new!(%{prompt: "hello"})
+    assert {:ok, %RunRequest{prompt: "hello", session_id: nil}} = RunRequest.new(%{prompt: "hello"})
+
+    assert %RunRequest{prompt: "hello", session_id: "session-1"} =
+             RunRequest.new!(%{prompt: "hello", session_id: "session-1"})
+
     assert {:error, _} = RunRequest.new(%{})
     assert_raise ArgumentError, ~r/Invalid Jido.Harness.RunRequest/, fn -> RunRequest.new!(%{}) end
   end

--- a/test/jido_harness_test.exs
+++ b/test/jido_harness_test.exs
@@ -38,7 +38,7 @@ defmodule Jido.HarnessTest do
 
   test "run/3 delegates to configured adapter modules" do
     Application.put_env(:jido_harness, :providers, %{stub: AdapterStub})
-    request_opts = [cwd: "/tmp/project"]
+    request_opts = [cwd: "/tmp/project", session_id: "session-resume-1"]
     runtime_opts = [transport: :exec]
 
     assert {:ok, stream} = Jido.Harness.run(:stub, "hello", request_opts ++ runtime_opts)
@@ -47,6 +47,7 @@ defmodule Jido.HarnessTest do
     assert_receive {:adapter_stub_run, request, [transport: :exec]}
     assert request.prompt == "hello"
     assert request.cwd == "/tmp/project"
+    assert request.session_id == "session-resume-1"
     assert [%Jido.Harness.Event{type: :session_started}] = events
   end
 


### PR DESCRIPTION
## Summary
- add optional provider-neutral session_id to RunRequest
- pass session_id through the Jido.Harness.run/3 facade
- document adapter resume semantics and add regression coverage

Fixes #25.

## Verification
- mix test
- git diff --check