### PR TITLE
feat(grok): support 1.0 streaming events

### DIFF
--- a/lib/jido_harness/adapters/cli_mapper.ex
+++ b/lib/jido_harness/adapters/cli_mapper.ex
@@ -20,7 +20,7 @@ defmodule Jido.Harness.Adapters.CLIMapper do
   @spec gemini(term(), String.t() | nil) :: {[Event.t()], String.t() | nil}
   def gemini(event, session_id), do: Gemini.map(event, session_id)
 
-  @doc "Maps a Grok streaming-json record."
-  @spec grok(term()) :: [Event.t()]
-  def grok(event), do: Grok.map(event)
+  @doc "Maps a Grok streaming-json record while removing duplicate terminal usage."
+  @spec grok(term(), map() | nil) :: {[Event.t()], map()}
+  def grok(event, state), do: Grok.map(event, state)
 end

--- a/lib/jido_harness/adapters/cli_mapper.ex
+++ b/lib/jido_harness/adapters/cli_mapper.ex
@@ -1,7 +1,7 @@
 defmodule Jido.Harness.Adapters.CLIMapper do
   @moduledoc false
 
-  alias Jido.Harness.Adapters.CLIMapper.{ClaudeStream, Codex, Gemini}
+  alias Jido.Harness.Adapters.CLIMapper.{ClaudeStream, Codex, Gemini, Grok}
   alias Jido.Harness.Event
 
   @doc "Maps an Amp stream-json record."
@@ -19,4 +19,8 @@ defmodule Jido.Harness.Adapters.CLIMapper do
   @doc "Maps a Gemini stream-json record while carrying its session identifier."
   @spec gemini(term(), String.t() | nil) :: {[Event.t()], String.t() | nil}
   def gemini(event, session_id), do: Gemini.map(event, session_id)
+
+  @doc "Maps a Grok streaming-json record."
+  @spec grok(term()) :: [Event.t()]
+  def grok(event), do: Grok.map(event)
 end

--- a/lib/jido_harness/adapters/cli_mapper/grok.ex
+++ b/lib/jido_harness/adapters/cli_mapper/grok.ex
@@ -5,21 +5,24 @@ defmodule Jido.Harness.Adapters.CLIMapper.Grok do
   alias Jido.Harness.Event
 
   @doc "Maps one Grok streaming-json record to zero or more harness events."
-  @spec map(term()) :: [Event.t()]
-  def map(%{"type" => "thought", "data" => text} = raw) when is_binary(text) do
-    maybe_text(:thinking_delta, text, raw)
+  @spec map(term(), map() | nil) :: {[Event.t()], map()}
+  def map(raw, state)
+
+  def map(%{"type" => "thought", "data" => text} = raw, state) when is_binary(text) do
+    mapped(maybe_text(:thinking_delta, text, raw), state)
   end
 
-  def map(%{"type" => "text", "data" => text} = raw) when is_binary(text) do
-    maybe_text(:output_text_delta, text, raw)
+  def map(%{"type" => "text", "data" => text} = raw, state) when is_binary(text) do
+    mapped(maybe_text(:output_text_delta, text, raw), state)
   end
 
-  def map(%{"type" => "usage", "usage" => usage} = raw) when is_map(usage) do
-    [Helpers.event(:grok, :usage, session_id(raw), normalize_usage(usage), raw)]
+  def map(%{"type" => "usage", "usage" => usage} = raw, state) when is_map(usage) do
+    usage = normalize_usage(usage)
+    {[usage_event(raw, usage)], Map.put(normalize_state(state), :last_usage, usage)}
   end
 
-  def map(%{"type" => "tool_call"} = raw) do
-    [
+  def map(%{"type" => "tool_call"} = raw, state) do
+    event =
       Helpers.event(
         :grok,
         :tool_call,
@@ -31,12 +34,13 @@ defmodule Jido.Harness.Adapters.CLIMapper.Grok do
         },
         raw
       )
-    ]
+
+    mapped([event], state)
   end
 
-  def map(%{"type" => "tool_call_update", "status" => status} = raw)
-      when status in ["completed", "failed", "error"] do
-    [
+  def map(%{"type" => "tool_call_update", "status" => status} = raw, state)
+      when status in ["completed", "failed", "error", "cancelled", "canceled"] do
+    event =
       Helpers.event(
         :grok,
         :tool_result,
@@ -44,68 +48,26 @@ defmodule Jido.Harness.Adapters.CLIMapper.Grok do
         %{
           "output" => raw["rawOutput"] || raw["content"],
           "call_id" => raw["toolCallId"],
-          "is_error" => status in ["failed", "error"]
+          "is_error" => status != "completed"
         },
         raw
       )
-    ]
+
+    mapped([event], state)
   end
 
-  def map(%{"type" => "error"} = raw) do
-    [
-      Helpers.event(
-        :grok,
-        :run_failed,
-        session_id(raw),
-        %{"error" => raw["message"] || raw["error"] || raw["data"] || "Grok failed"},
-        raw
-      )
-    ]
+  def map(%{"type" => "error"} = raw, state) do
+    event = Helpers.event(:grok, :run_failed, session_id(raw), %{"error" => error_message(raw)}, raw)
+    mapped([event], state)
   end
 
-  def map(%{"type" => "end", "stopReason" => stop_reason} = raw)
-      when stop_reason in ["cancelled", "canceled"] do
-    usage_event(raw) ++
-      [
-        Helpers.event(
-          :grok,
-          :run_cancelled,
-          session_id(raw),
-          end_payload(raw),
-          raw
-        )
-      ]
+  def map(%{"type" => "end"} = raw, state) do
+    {usage_events, state} = terminal_usage(raw, normalize_state(state))
+    {usage_events ++ [terminal_event(raw)], state}
   end
 
-  def map(%{"type" => "end", "stopReason" => stop_reason} = raw)
-      when stop_reason in ["error", "failed"] do
-    usage_event(raw) ++
-      [
-        Helpers.event(
-          :grok,
-          :run_failed,
-          session_id(raw),
-          Map.put(end_payload(raw), "error", raw["message"] || "Grok failed"),
-          raw
-        )
-      ]
-  end
-
-  def map(%{"type" => "end"} = raw) do
-    usage_event(raw) ++
-      [
-        Helpers.event(
-          :grok,
-          :run_completed,
-          session_id(raw),
-          end_payload(raw),
-          raw
-        )
-      ]
-  end
-
-  def map(raw) do
-    [
+  def map(raw, state) do
+    event =
       Helpers.event(
         :grok,
         :provider_event,
@@ -113,35 +75,70 @@ defmodule Jido.Harness.Adapters.CLIMapper.Grok do
         %{"type" => event_type(raw), "mapped" => false},
         raw
       )
-    ]
+
+    mapped([event], state)
   end
 
-  defp usage_event(%{"usage" => usage} = raw) when is_map(usage) do
-    [Helpers.event(:grok, :usage, session_id(raw), normalize_usage(usage), raw)]
+  defp terminal_usage(%{"usage" => usage} = raw, state) when is_map(usage) do
+    usage = normalize_usage(usage)
+    duplicate? = usage == state.last_usage
+    state = Map.put(state, :last_usage, usage)
+
+    if duplicate? do
+      {[], state}
+    else
+      {[usage_event(raw, usage)], state}
+    end
   end
 
-  defp usage_event(_raw), do: []
+  defp terminal_usage(_raw, state), do: {[], state}
+
+  defp terminal_event(%{"stopReason" => stop_reason} = raw)
+       when stop_reason in ["cancelled", "canceled"] do
+    Helpers.event(:grok, :run_cancelled, session_id(raw), end_payload(raw), raw)
+  end
+
+  defp terminal_event(%{"stopReason" => stop_reason} = raw) when stop_reason in ["error", "failed"] do
+    payload = Map.put(end_payload(raw), "error", error_message(raw))
+    Helpers.event(:grok, :run_failed, session_id(raw), payload, raw)
+  end
+
+  defp terminal_event(raw), do: Helpers.event(:grok, :run_completed, session_id(raw), end_payload(raw), raw)
+
+  defp usage_event(raw, usage), do: Helpers.event(:grok, :usage, session_id(raw), usage, raw)
 
   defp normalize_usage(usage) do
     Map.put_new_lazy(usage, "total_tokens", fn ->
-      Enum.sum([
-        usage["input_tokens"] || 0,
-        usage["output_tokens"] || 0,
-        usage["cache_read_input_tokens"] || 0,
-        usage["cache_creation_input_tokens"] || 0
-      ])
+      ["input_tokens", "output_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"]
+      |> Enum.map(&numeric_value(usage[&1]))
+      |> Enum.sum()
     end)
   end
 
   defp end_payload(raw) do
-    %{
-      "stop_reason" => raw["stopReason"],
-      "request_id" => raw["requestId"],
-      "num_turns" => raw["num_turns"],
-      "cost_usd" => raw["total_cost_usd"]
-    }
+    [
+      {"stop_reason", raw["stopReason"]},
+      {"request_id", raw["requestId"]},
+      {"num_turns", raw["num_turns"]},
+      {"cost_usd", raw["total_cost_usd"]}
+    ]
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
   end
 
+  defp error_message(raw) do
+    case raw["message"] || raw["error"] || raw["data"] do
+      value when is_binary(value) and value != "" -> value
+      nil -> "Grok failed"
+      value -> inspect(value)
+    end
+  end
+
+  defp numeric_value(value) when is_number(value), do: value
+  defp numeric_value(_value), do: 0
+  defp mapped(events, state), do: {events, normalize_state(state)}
+  defp normalize_state(state) when is_map(state), do: Map.put_new(state, :last_usage, nil)
+  defp normalize_state(_state), do: %{last_usage: nil}
   defp maybe_text(_type, "", _raw), do: []
   defp maybe_text(type, text, raw), do: [Helpers.event(:grok, type, session_id(raw), %{"text" => text}, raw)]
   defp session_id(raw) when is_map(raw), do: raw["sessionId"] || raw["session_id"]

--- a/lib/jido_harness/adapters/cli_mapper/grok.ex
+++ b/lib/jido_harness/adapters/cli_mapper/grok.ex
@@ -1,0 +1,151 @@
+defmodule Jido.Harness.Adapters.CLIMapper.Grok do
+  @moduledoc false
+
+  alias Jido.Harness.Adapters.Helpers
+  alias Jido.Harness.Event
+
+  @doc "Maps one Grok streaming-json record to zero or more harness events."
+  @spec map(term()) :: [Event.t()]
+  def map(%{"type" => "thought", "data" => text} = raw) when is_binary(text) do
+    maybe_text(:thinking_delta, text, raw)
+  end
+
+  def map(%{"type" => "text", "data" => text} = raw) when is_binary(text) do
+    maybe_text(:output_text_delta, text, raw)
+  end
+
+  def map(%{"type" => "usage", "usage" => usage} = raw) when is_map(usage) do
+    [Helpers.event(:grok, :usage, session_id(raw), normalize_usage(usage), raw)]
+  end
+
+  def map(%{"type" => "tool_call"} = raw) do
+    [
+      Helpers.event(
+        :grok,
+        :tool_call,
+        session_id(raw),
+        %{
+          "name" => raw["toolName"] || raw["title"],
+          "input" => raw["rawInput"] || %{},
+          "call_id" => raw["toolCallId"]
+        },
+        raw
+      )
+    ]
+  end
+
+  def map(%{"type" => "tool_call_update", "status" => status} = raw)
+      when status in ["completed", "failed", "error"] do
+    [
+      Helpers.event(
+        :grok,
+        :tool_result,
+        session_id(raw),
+        %{
+          "output" => raw["rawOutput"] || raw["content"],
+          "call_id" => raw["toolCallId"],
+          "is_error" => status in ["failed", "error"]
+        },
+        raw
+      )
+    ]
+  end
+
+  def map(%{"type" => "error"} = raw) do
+    [
+      Helpers.event(
+        :grok,
+        :run_failed,
+        session_id(raw),
+        %{"error" => raw["message"] || raw["error"] || raw["data"] || "Grok failed"},
+        raw
+      )
+    ]
+  end
+
+  def map(%{"type" => "end", "stopReason" => stop_reason} = raw)
+      when stop_reason in ["cancelled", "canceled"] do
+    usage_event(raw) ++
+      [
+        Helpers.event(
+          :grok,
+          :run_cancelled,
+          session_id(raw),
+          end_payload(raw),
+          raw
+        )
+      ]
+  end
+
+  def map(%{"type" => "end", "stopReason" => stop_reason} = raw)
+      when stop_reason in ["error", "failed"] do
+    usage_event(raw) ++
+      [
+        Helpers.event(
+          :grok,
+          :run_failed,
+          session_id(raw),
+          Map.put(end_payload(raw), "error", raw["message"] || "Grok failed"),
+          raw
+        )
+      ]
+  end
+
+  def map(%{"type" => "end"} = raw) do
+    usage_event(raw) ++
+      [
+        Helpers.event(
+          :grok,
+          :run_completed,
+          session_id(raw),
+          end_payload(raw),
+          raw
+        )
+      ]
+  end
+
+  def map(raw) do
+    [
+      Helpers.event(
+        :grok,
+        :provider_event,
+        session_id(raw),
+        %{"type" => event_type(raw), "mapped" => false},
+        raw
+      )
+    ]
+  end
+
+  defp usage_event(%{"usage" => usage} = raw) when is_map(usage) do
+    [Helpers.event(:grok, :usage, session_id(raw), normalize_usage(usage), raw)]
+  end
+
+  defp usage_event(_raw), do: []
+
+  defp normalize_usage(usage) do
+    Map.put_new_lazy(usage, "total_tokens", fn ->
+      Enum.sum([
+        usage["input_tokens"] || 0,
+        usage["output_tokens"] || 0,
+        usage["cache_read_input_tokens"] || 0,
+        usage["cache_creation_input_tokens"] || 0
+      ])
+    end)
+  end
+
+  defp end_payload(raw) do
+    %{
+      "stop_reason" => raw["stopReason"],
+      "request_id" => raw["requestId"],
+      "num_turns" => raw["num_turns"],
+      "cost_usd" => raw["total_cost_usd"]
+    }
+  end
+
+  defp maybe_text(_type, "", _raw), do: []
+  defp maybe_text(type, text, raw), do: [Helpers.event(:grok, type, session_id(raw), %{"text" => text}, raw)]
+  defp session_id(raw) when is_map(raw), do: raw["sessionId"] || raw["session_id"]
+  defp session_id(_raw), do: nil
+  defp event_type(raw) when is_map(raw), do: raw["type"] || "unknown"
+  defp event_type(_raw), do: "unknown"
+end

--- a/lib/jido_harness/adapters/grok.ex
+++ b/lib/jido_harness/adapters/grok.ex
@@ -75,7 +75,7 @@ defmodule Jido.Harness.Adapters.Grok do
     with :ok <- validate_options(request, options),
          {:ok, argv} <- build_argv(request, options) do
       executable = options[:cli_path] || Helpers.cli_path(context.config, spec().executable)
-      CLIStream.run(:grok, request, context, executable, argv, &CLIMapper.grok/1)
+      CLIStream.run(:grok, request, context, executable, argv, &CLIMapper.grok/2, %{})
     end
   end
 

--- a/lib/jido_harness/adapters/grok.ex
+++ b/lib/jido_harness/adapters/grok.ex
@@ -4,9 +4,9 @@ defmodule Jido.Harness.Adapters.Grok do
 
   alias Jido.Harness.{
     AdapterSpec,
+    Adapters.CLIMapper,
     Adapters.CLIStream,
     Adapters.Helpers,
-    Adapters.JSONMapper,
     Capabilities,
     Error,
     RunRequest
@@ -75,7 +75,7 @@ defmodule Jido.Harness.Adapters.Grok do
     with :ok <- validate_options(request, options),
          {:ok, argv} <- build_argv(request, options) do
       executable = options[:cli_path] || Helpers.cli_path(context.config, spec().executable)
-      CLIStream.run(:grok, request, context, executable, argv, &JSONMapper.map(:grok, &1))
+      CLIStream.run(:grok, request, context, executable, argv, &CLIMapper.grok/1)
     end
   end
 

--- a/test/jido_harness/adapter_test.exs
+++ b/test/jido_harness/adapter_test.exs
@@ -425,9 +425,76 @@ defmodule Jido.Harness.AdapterTest do
              OpenCode.build_argv(open_request, %{extra_args: ["--format=json"]})
   end
 
+  test "Grok maps the 1.0 streaming event format" do
+    assert [%Event{provider: :grok, type: :thinking_delta, payload: %{"text" => "checking"}}] =
+             CLIMapper.grok(%{"type" => "thought", "data" => "checking"})
+
+    assert [%Event{provider: :grok, type: :output_text_delta, payload: %{"text" => "hello"}}] =
+             CLIMapper.grok(%{"type" => "text", "data" => "hello"})
+
+    assert [%Event{type: :usage, payload: %{"total_tokens" => 16}}] =
+             CLIMapper.grok(%{
+               "type" => "usage",
+               "usage" => %{
+                 "input_tokens" => 7,
+                 "output_tokens" => 2,
+                 "cache_read_input_tokens" => 5,
+                 "cache_creation_input_tokens" => 2
+               }
+             })
+
+    assert [
+             %Event{
+               type: :tool_call,
+               payload: %{"name" => "read_file", "input" => %{"target_file" => "README.md"}, "call_id" => "call-1"}
+             }
+           ] =
+             CLIMapper.grok(%{
+               "type" => "tool_call",
+               "toolCallId" => "call-1",
+               "toolName" => "read_file",
+               "rawInput" => %{"target_file" => "README.md"}
+             })
+
+    assert [
+             %Event{
+               type: :tool_result,
+               payload: %{"output" => %{"content" => "# Jido.Harness"}, "call_id" => "call-1", "is_error" => false}
+             }
+           ] =
+             CLIMapper.grok(%{
+               "type" => "tool_call_update",
+               "toolCallId" => "call-1",
+               "status" => "completed",
+               "rawOutput" => %{"content" => "# Jido.Harness"}
+             })
+
+    assert [
+             %Event{type: :usage, provider_session_id: "session-1", payload: %{"total_tokens" => 9}},
+             %Event{
+               type: :run_completed,
+               provider_session_id: "session-1",
+               payload: %{"stop_reason" => "end_turn", "request_id" => "request-1"}
+             }
+           ] =
+             CLIMapper.grok(%{
+               "type" => "end",
+               "stopReason" => "end_turn",
+               "sessionId" => "session-1",
+               "requestId" => "request-1",
+               "usage" => %{"input_tokens" => 7, "output_tokens" => 2}
+             })
+
+    assert [%Event{type: :run_cancelled, provider_session_id: "session-2"}] =
+             CLIMapper.grok(%{"type" => "end", "stopReason" => "cancelled", "sessionId" => "session-2"})
+
+    assert [%Event{type: :provider_event, payload: %{"type" => "available_commands", "mapped" => false}}] =
+             CLIMapper.grok(%{"type" => "available_commands", "tools" => ["read_file"]})
+  end
+
   test "generic JSON mapping preserves unknown events and emits canonical terminals" do
     assert %Event{type: :output_text_delta, payload: %{"text" => "hello"}} =
-             JSONMapper.map(:grok, %{"type" => "delta", "text" => "hello"})
+             JSONMapper.map(:other, %{"type" => "delta", "text" => "hello"})
 
     events = List.wrap(JSONMapper.map(:opencode, %{"type" => "completed", "text" => "done"}))
     assert Enum.map(events, & &1.type) == [:output_text_final, :run_completed]
@@ -437,7 +504,7 @@ defmodule Jido.Harness.AdapterTest do
              payload: %{"type" => "new-event", "mapped" => false},
              raw: %{"type" => "new-event"}
            } =
-             JSONMapper.map(:grok, %{"type" => "new-event"})
+             JSONMapper.map(:other, %{"type" => "new-event"})
   end
 
   test "Codex maps direct exec JSONL records into canonical events" do

--- a/test/jido_harness/adapter_test.exs
+++ b/test/jido_harness/adapter_test.exs
@@ -425,71 +425,122 @@ defmodule Jido.Harness.AdapterTest do
              OpenCode.build_argv(open_request, %{extra_args: ["--format=json"]})
   end
 
-  test "Grok maps the 1.0 streaming event format" do
-    assert [%Event{provider: :grok, type: :thinking_delta, payload: %{"text" => "checking"}}] =
-             CLIMapper.grok(%{"type" => "thought", "data" => "checking"})
+  test "Grok maps text, thought, and unknown 1.0 stream records" do
+    assert {[%Event{provider: :grok, type: :thinking_delta, payload: %{"text" => "checking"}}], _state} =
+             CLIMapper.grok(%{"type" => "thought", "data" => "checking"}, %{})
 
-    assert [%Event{provider: :grok, type: :output_text_delta, payload: %{"text" => "hello"}}] =
-             CLIMapper.grok(%{"type" => "text", "data" => "hello"})
+    assert {[%Event{provider: :grok, type: :output_text_delta, payload: %{"text" => " hello"}}], _state} =
+             CLIMapper.grok(%{"type" => "text", "data" => " hello"}, %{})
 
-    assert [%Event{type: :usage, payload: %{"total_tokens" => 16}}] =
-             CLIMapper.grok(%{
-               "type" => "usage",
-               "usage" => %{
-                 "input_tokens" => 7,
-                 "output_tokens" => 2,
-                 "cache_read_input_tokens" => 5,
-                 "cache_creation_input_tokens" => 2
+    assert {[], _state} = CLIMapper.grok(%{"type" => "text", "data" => ""}, %{})
+
+    assert {[%Event{type: :provider_event, payload: %{"type" => "available_commands", "mapped" => false}}], _state} =
+             CLIMapper.grok(%{"type" => "available_commands", "tools" => ["read_file"]}, %{})
+  end
+
+  test "Grok maps tool calls and terminal tool updates" do
+    assert {
+             [
+               %Event{
+                 type: :tool_call,
+                 payload: %{
+                   "name" => "read_file",
+                   "input" => %{"target_file" => "README.md"},
+                   "call_id" => "call-1"
+                 }
                }
-             })
+             ],
+             _state
+           } =
+             CLIMapper.grok(
+               %{
+                 "type" => "tool_call",
+                 "toolCallId" => "call-1",
+                 "toolName" => "read_file",
+                 "rawInput" => %{"target_file" => "README.md"}
+               },
+               %{}
+             )
 
-    assert [
-             %Event{
-               type: :tool_call,
-               payload: %{"name" => "read_file", "input" => %{"target_file" => "README.md"}, "call_id" => "call-1"}
-             }
-           ] =
-             CLIMapper.grok(%{
-               "type" => "tool_call",
-               "toolCallId" => "call-1",
-               "toolName" => "read_file",
-               "rawInput" => %{"target_file" => "README.md"}
-             })
+    assert {
+             [
+               %Event{
+                 type: :tool_result,
+                 payload: %{
+                   "output" => %{"content" => "# Jido.Harness"},
+                   "call_id" => "call-1",
+                   "is_error" => false
+                 }
+               }
+             ],
+             _state
+           } =
+             CLIMapper.grok(
+               %{
+                 "type" => "tool_call_update",
+                 "toolCallId" => "call-1",
+                 "status" => "completed",
+                 "rawOutput" => %{"content" => "# Jido.Harness"}
+               },
+               %{}
+             )
 
-    assert [
-             %Event{
-               type: :tool_result,
-               payload: %{"output" => %{"content" => "# Jido.Harness"}, "call_id" => "call-1", "is_error" => false}
-             }
-           ] =
-             CLIMapper.grok(%{
-               "type" => "tool_call_update",
-               "toolCallId" => "call-1",
-               "status" => "completed",
-               "rawOutput" => %{"content" => "# Jido.Harness"}
-             })
+    assert {[%Event{type: :tool_result, payload: %{"is_error" => true}}], _state} =
+             CLIMapper.grok(
+               %{"type" => "tool_call_update", "toolCallId" => "call-2", "status" => "cancelled"},
+               %{}
+             )
+  end
 
-    assert [
-             %Event{type: :usage, provider_session_id: "session-1", payload: %{"total_tokens" => 9}},
-             %Event{
-               type: :run_completed,
-               provider_session_id: "session-1",
-               payload: %{"stop_reason" => "end_turn", "request_id" => "request-1"}
-             }
-           ] =
-             CLIMapper.grok(%{
-               "type" => "end",
-               "stopReason" => "end_turn",
-               "sessionId" => "session-1",
-               "requestId" => "request-1",
-               "usage" => %{"input_tokens" => 7, "output_tokens" => 2}
-             })
+  test "Grok emits changed usage once and keeps terminal session identity" do
+    usage = %{
+      "input_tokens" => 7,
+      "output_tokens" => 2,
+      "cache_read_input_tokens" => 5,
+      "cache_creation_input_tokens" => 2
+    }
 
-    assert [%Event{type: :run_cancelled, provider_session_id: "session-2"}] =
-             CLIMapper.grok(%{"type" => "end", "stopReason" => "cancelled", "sessionId" => "session-2"})
+    assert {[%Event{type: :usage, payload: %{"total_tokens" => 16}}], state} =
+             CLIMapper.grok(%{"type" => "usage", "usage" => usage}, %{})
 
-    assert [%Event{type: :provider_event, payload: %{"type" => "available_commands", "mapped" => false}}] =
-             CLIMapper.grok(%{"type" => "available_commands", "tools" => ["read_file"]})
+    assert {
+             [
+               %Event{
+                 type: :run_completed,
+                 provider_session_id: "session-1",
+                 payload: %{"stop_reason" => "end_turn", "request_id" => "request-1"}
+               }
+             ],
+             _state
+           } =
+             CLIMapper.grok(
+               %{
+                 "type" => "end",
+                 "stopReason" => "end_turn",
+                 "sessionId" => "session-1",
+                 "requestId" => "request-1",
+                 "usage" => usage
+               },
+               state
+             )
+
+    assert {[%Event{type: :usage, payload: %{"total_tokens" => 10}}, %Event{type: :run_completed}], _state} =
+             CLIMapper.grok(
+               %{"type" => "end", "stopReason" => "end_turn", "usage" => %{"input_tokens" => 8, "output_tokens" => 2}},
+               state
+             )
+  end
+
+  test "Grok maps cancellation and failure terminals" do
+    assert {[%Event{type: :run_cancelled, provider_session_id: "session-2", payload: %{"stop_reason" => "cancelled"}}],
+            _state} =
+             CLIMapper.grok(%{"type" => "end", "stopReason" => "cancelled", "sessionId" => "session-2"}, %{})
+
+    assert {[%Event{type: :run_failed, payload: %{"error" => "request failed"}}], _state} =
+             CLIMapper.grok(%{"type" => "error", "message" => "request failed"}, %{})
+
+    assert {[%Event{type: :run_failed, payload: %{"error" => "%{\"code\" => \"bad_request\"}"}}], _state} =
+             CLIMapper.grok(%{"type" => "end", "stopReason" => "failed", "data" => %{"code" => "bad_request"}}, %{})
   end
 
   test "generic JSON mapping preserves unknown events and emits canonical terminals" do

--- a/test/jido_harness/direct_cli_adapter_test.exs
+++ b/test/jido_harness/direct_cli_adapter_test.exs
@@ -6,7 +6,7 @@ defmodule Jido.Harness.DirectCLIAdapterTest do
     original = Application.get_env(:jido_harness, :provider_config, %{})
 
     provider_config =
-      [:amp, :claude, :codex, :gemini, :zai]
+      [:amp, :claude, :codex, :gemini, :grok, :zai]
       |> Map.new(&{&1, %{cli_path: fixture}})
 
     Application.put_env(:jido_harness, :provider_config, Map.merge(original, provider_config))
@@ -26,6 +26,7 @@ defmodule Jido.Harness.DirectCLIAdapterTest do
       claude: {"claude-ok", "claude-fixture-session"},
       codex: {"codex-ok", "codex-fixture-session"},
       gemini: {"gemini-ok", "gemini-fixture-session"},
+      grok: {"grok-ok", "grok-fixture-session"},
       zai: {"claude-ok", "claude-fixture-session"}
     }
 

--- a/test/support/fixtures/fake_stream_cli.exs
+++ b/test/support/fixtures/fake_stream_cli.exs
@@ -29,12 +29,21 @@ defmodule Jido.Harness.Fixture.StreamCLI do
       ~s("result":"amp-ok","usage":{"input_tokens":2,"output_tokens":1}})
   ]
 
+  @grok [
+    ~s({"type":"thought","data":"checking"}),
+    ~s({"type":"text","data":"grok-ok"}),
+    ~s({"type":"usage","usage":{"input_tokens":2,"output_tokens":1}}),
+    ~s({"type":"end","stopReason":"end_turn","sessionId":"grok-fixture-session",) <>
+      ~s("requestId":"grok-request","num_turns":1,"usage":{"input_tokens":2,"output_tokens":1}})
+  ]
+
   def run(args) do
     cond do
       "exec" in args and "--json" in args -> emit(@codex)
       "--prompt" in args -> emit(@gemini)
       "--print" in args -> emit(@claude)
       "--execute" in args -> emit(@amp)
+      "-p" in args and "streaming-json" in args -> emit(@grok)
       true -> unsupported()
     end
   end


### PR DESCRIPTION
## Summary

- add a Grok-specific mapper for the Grok 1.0 `streaming-json` event format
- normalize text, thought, usage, tool, error, cancellation, and completion records
- remove exact duplicate usage from the terminal record while keeping changed final usage
- keep unknown Grok records as provider events
- add mapper tests and a deterministic managed-run fixture

## Validation

- `mix test test/jido_harness/adapter_test.exs test/jido_harness/direct_cli_adapter_test.exs` (25 passed)
- `mix test` (111 passed, 55 excluded)
- `mix quality`
- `mix jido_harness.chat grok --timeout 120 --json`
- strict Grok smoke profile with the installed Grok 1.0.4 CLI

Closes #52