### PR TITLE
feat(escript): bootstrap erlexec native helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ mix jido_harness.chat codex
 
 The chat task may consume paid API or subscription usage.
 
+## Escript packaging
+
+An escript must extract the native `erlexec` helper before it starts
+Jido.Harness. Configure the escript with `app: nil` and
+`include_priv_for: [:erlexec]`, then call
+`Jido.Harness.Escript.bootstrap_erlexec/1` from its main function. See the
+[escript packaging guide](guides/escripts.md).
+
 ## First request
 
 ```elixir

--- a/fixtures/escript_fixture/.gitignore
+++ b/fixtures/escript_fixture/.gitignore
@@ -1,0 +1,1 @@
+mix.lock

--- a/fixtures/escript_fixture/lib/jido_harness_escript_fixture.ex
+++ b/fixtures/escript_fixture/lib/jido_harness_escript_fixture.ex
@@ -1,0 +1,15 @@
+defmodule JidoHarnessEscriptFixture do
+  def main(_arguments) do
+    cache_dir = System.fetch_env!("JIDO_HARNESS_ESCRIPT_CACHE_DIR")
+    Application.put_env(:jido_harness, :process_manager, %{journal_dir: Path.join(cache_dir, "journals")})
+
+    with {:ok, helper_path} <- Jido.Harness.Escript.bootstrap_erlexec(cache_dir: cache_dir),
+         {:ok, _applications} <- Application.ensure_all_started(:jido_harness) do
+      IO.puts("BOOTSTRAP_OK=" <> helper_path)
+    else
+      {:error, error} ->
+        IO.puts(:stderr, Exception.message(error))
+        System.halt(1)
+    end
+  end
+end

--- a/fixtures/escript_fixture/mix.exs
+++ b/fixtures/escript_fixture/mix.exs
@@ -1,0 +1,20 @@
+defmodule JidoHarnessEscriptFixture.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :jido_harness_escript_fixture,
+      version: "0.0.0",
+      elixir: "~> 1.19",
+      deps: [{:jido_harness, path: Path.expand("../..", __DIR__)}],
+      escript: [
+        main_module: JidoHarnessEscriptFixture,
+        app: nil,
+        include_priv_for: [:erlexec],
+        path: System.fetch_env!("JIDO_HARNESS_ESCRIPT_PATH")
+      ]
+    ]
+  end
+
+  def application, do: []
+end

--- a/guides/escripts.md
+++ b/guides/escripts.md
@@ -1,0 +1,71 @@
+# Escript packaging
+
+Jido.Harness uses `erlexec` and its native `exec-port` helper to manage OS
+processes. A Mix escript can include this helper, but it cannot execute a file
+inside the escript archive. Extract and configure the helper before the
+applications start.
+
+## Configure the escript
+
+Set `app: nil` so that Mix does not start `erlexec` before your main function.
+Use `include_priv_for: [:erlexec]` to add the native helper to the archive:
+
+```elixir
+def project do
+  [
+    app: :my_cli,
+    version: "0.1.0",
+    escript: [
+      main_module: MyCLI,
+      app: nil,
+      include_priv_for: [:erlexec]
+    ]
+  ]
+end
+```
+
+## Bootstrap before application startup
+
+Call `Jido.Harness.Escript.bootstrap_erlexec/1` before you start
+`:jido_harness`:
+
+```elixir
+defmodule MyCLI do
+  def main(args) do
+    with {:ok, _helper_path} <- Jido.Harness.Escript.bootstrap_erlexec(),
+         {:ok, _applications} <- Application.ensure_all_started(:jido_harness) do
+      run(args)
+    else
+      {:error, error} ->
+        IO.puts(:stderr, Exception.message(error))
+        System.halt(1)
+    end
+  end
+end
+```
+
+The bootstrap function selects only `erlexec/priv/SYSTEM_ARCH/exec-port` from
+the archive. It writes the helper below the private user-cache directory with
+mode `0700` and sets the `:erlexec, :portexe` application value. Repeated calls
+for the same helper content reuse the cached file.
+
+Use `cache_dir: path` when the default user-cache directory is not suitable:
+
+```elixir
+Jido.Harness.Escript.bootstrap_erlexec(cache_dir: cache_dir)
+```
+
+Do not call the bootstrap function after `:erlexec` starts. The running port
+process cannot change its executable path.
+
+## Build and verify
+
+Build the escript and run a provider readiness check from the packaged CLI:
+
+```console
+mix escript.build
+./my_cli check codex
+```
+
+The target machine must use the same system architecture as the included
+`exec-port` file. Build one escript artifact for each supported architecture.

--- a/lib/jido_harness/escript.ex
+++ b/lib/jido_harness/escript.ex
@@ -1,0 +1,220 @@
+defmodule Jido.Harness.Escript do
+  @moduledoc """
+  Bootstraps the native `erlexec` helper from a Mix escript archive.
+
+  Mix can include the `erlexec` private directory in an escript, but the native
+  `exec-port` file cannot run from inside the archive. `bootstrap_erlexec/1`
+  selects the file for the current system architecture, copies it to a private
+  user-cache directory, makes it executable, and configures `:erlexec` to use
+  that path.
+
+  Call this function before `:erlexec` or `:jido_harness` starts. The escript
+  must use `app: nil` and `include_priv_for: [:erlexec]`.
+
+      def main(_args) do
+        with {:ok, _path} <- Jido.Harness.Escript.bootstrap_erlexec(),
+             {:ok, _apps} <- Application.ensure_all_started(:jido_harness) do
+          run_cli()
+        end
+      end
+
+  See the [escript packaging guide](escripts.html) for the complete Mix
+  configuration.
+  """
+
+  alias Jido.Harness.Error
+
+  @executable "exec-port"
+
+  @doc """
+  Extracts and configures the `erlexec` helper for the current escript.
+
+  Options:
+
+  * `:escript_path` overrides `:escript.script_name/0`. This is useful for
+    custom launchers and tests.
+  * `:cache_dir` overrides the user-cache base directory. The helper is stored
+    below an architecture and content-specific subdirectory.
+
+  The function is idempotent for the same helper content. It must run before
+  `:erlexec` starts.
+  """
+  @spec bootstrap_erlexec(keyword()) :: {:ok, String.t()} | {:error, Error.t()}
+  def bootstrap_erlexec(options \\ [])
+
+  def bootstrap_erlexec(options) when is_list(options) do
+    if Keyword.keyword?(options) do
+      with {:ok, escript_path} <- option_path(options, :escript_path, default_escript_path()),
+           {:ok, cache_dir} <- option_path(options, :cache_dir, default_cache_dir()),
+           :ok <- ensure_erlexec_stopped(),
+           {:ok, archive} <- extract_archive(escript_path),
+           {:ok, helper} <- find_helper(archive),
+           {:ok, path} <- cache_helper(cache_dir, helper) do
+        Application.put_env(:erlexec, :portexe, path)
+        {:ok, path}
+      end
+    else
+      configuration_error("escript bootstrap options must be a keyword list")
+    end
+  rescue
+    exception ->
+      configuration_error("could not bootstrap erlexec from the escript",
+        cause: exception,
+        details: %{message: Exception.message(exception)}
+      )
+  catch
+    kind, reason ->
+      configuration_error("could not bootstrap erlexec from the escript",
+        cause: {kind, reason},
+        details: %{reason: inspect(reason)}
+      )
+  end
+
+  def bootstrap_erlexec(_options),
+    do: configuration_error("escript bootstrap options must be a keyword list")
+
+  defp default_escript_path, do: :escript.script_name()
+  defp default_cache_dir, do: :filename.basedir(:user_cache, "jido_harness")
+
+  defp option_path(options, key, default) do
+    case Keyword.get(options, key, default) do
+      path when is_binary(path) and path != "" -> {:ok, Path.expand(path)}
+      path when is_list(path) and path != [] -> {:ok, path |> List.to_string() |> Path.expand()}
+      _value -> configuration_error("#{key} must be a non-empty path", details: %{option: key})
+    end
+  end
+
+  defp ensure_erlexec_stopped do
+    if not is_nil(Process.whereis(:exec)) or application_started?(:erlexec) do
+      configuration_error("erlexec is already started; bootstrap it before starting jido_harness")
+    else
+      :ok
+    end
+  end
+
+  defp application_started?(application) do
+    Enum.any?(Application.started_applications(), fn {started, _description, _version} ->
+      started == application
+    end)
+  end
+
+  defp extract_archive(escript_path) do
+    case :escript.extract(String.to_charlist(escript_path), []) do
+      {:ok, sections} ->
+        case List.keyfind(sections, :archive, 0) do
+          {:archive, archive} when is_binary(archive) -> {:ok, archive}
+          _missing -> configuration_error("escript does not contain an archive", details: %{path: escript_path})
+        end
+
+      {:error, reason} ->
+        configuration_error("could not read the escript archive",
+          details: %{path: escript_path, reason: inspect(reason)}
+        )
+    end
+  end
+
+  defp find_helper(archive) do
+    architecture = :erlang.system_info(:system_architecture) |> List.to_string()
+
+    case archive_helpers(archive) do
+      {:ok, helpers} ->
+        select_helper(helpers, architecture)
+
+      {:error, reason} ->
+        configuration_error("could not inspect the escript archive", details: %{reason: inspect(reason)})
+    end
+  end
+
+  defp archive_helpers(archive) do
+    :zip.foldl(
+      fn name, _get_info, get_binary, helpers ->
+        path = to_string(name)
+        if Path.basename(path) == @executable, do: [{path, get_binary.()} | helpers], else: helpers
+      end,
+      [],
+      {~c"jido-harness-escript.zip", archive}
+    )
+  end
+
+  defp select_helper(helpers, architecture) do
+    matches = Enum.filter(helpers, fn {path, _binary} -> helper_for_architecture?(path, architecture) end)
+
+    case matches do
+      [{_path, binary}] ->
+        {:ok, %{architecture: architecture, binary: binary}}
+
+      [] ->
+        configuration_error("escript does not contain an erlexec helper for the current architecture",
+          details: %{architecture: architecture, entries: Enum.map(helpers, &elem(&1, 0))}
+        )
+
+      many ->
+        configuration_error("escript contains multiple erlexec helpers for the current architecture",
+          details: %{architecture: architecture, entries: Enum.map(many, &elem(&1, 0))}
+        )
+    end
+  end
+
+  defp helper_for_architecture?(path, architecture) do
+    path
+    |> String.split("/", trim: true)
+    |> Enum.chunk_every(4, 1, :discard)
+    |> Enum.any?(&(&1 == ["erlexec", "priv", architecture, @executable]))
+  end
+
+  defp cache_helper(cache_dir, %{architecture: architecture, binary: binary}) do
+    fingerprint = "#{byte_size(binary)}-#{Integer.to_string(:erlang.phash2(binary), 16)}"
+    directory = Path.join([cache_dir, "erlexec", architecture, fingerprint])
+    target = Path.join(directory, @executable)
+
+    with :ok <- File.mkdir_p(directory),
+         :ok <- File.chmod(directory, 0o700),
+         :ok <- store_helper(target, binary),
+         :ok <- File.chmod(target, 0o700) do
+      {:ok, target}
+    else
+      {:error, reason} ->
+        configuration_error("could not write the erlexec helper to the cache",
+          details: %{path: target, reason: inspect(reason)}
+        )
+    end
+  end
+
+  defp store_helper(target, binary) do
+    case File.read(target) do
+      {:ok, ^binary} -> :ok
+      _missing_or_changed -> atomic_write(target, binary)
+    end
+  end
+
+  defp atomic_write(target, binary) do
+    temporary = target <> ".tmp-#{System.pid()}-#{System.unique_integer([:positive])}"
+
+    try do
+      with :ok <- File.write(temporary, binary, [:binary, :exclusive]),
+           :ok <- File.chmod(temporary, 0o700),
+           :ok <- replace_file(temporary, target) do
+        :ok
+      end
+    after
+      File.rm(temporary)
+    end
+  end
+
+  defp replace_file(source, target) do
+    case File.rename(source, target) do
+      :ok ->
+        :ok
+
+      {:error, :eexist} ->
+        with :ok <- File.rm(target), do: File.rename(source, target)
+
+      error ->
+        error
+    end
+  end
+
+  defp configuration_error(message, options \\ []) do
+    {:error, Error.new(:configuration, message, options)}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,7 @@ defmodule Jido.Harness.MixProject do
           "guides/detached_runs.md",
           "guides/interactive_sessions.md",
           "guides/managed_processes.md",
+          "guides/escripts.md",
           "guides/normalization_and_data_model.md",
           "guides/streaming_replay_and_retention.md",
           "guides/ownership_timeouts_and_cancellation.md",
@@ -64,7 +65,8 @@ defmodule Jido.Harness.MixProject do
             "guides/one_shot_requests.md",
             "guides/detached_runs.md",
             "guides/interactive_sessions.md",
-            "guides/managed_processes.md"
+            "guides/managed_processes.md",
+            "guides/escripts.md"
           ],
           "Shared concepts": [
             "guides/normalization_and_data_model.md",
@@ -98,7 +100,8 @@ defmodule Jido.Harness.MixProject do
             Jido.Harness,
             Jido.Harness.Run,
             Jido.Harness.Session,
-            Jido.Harness.Process
+            Jido.Harness.Process,
+            Jido.Harness.Escript
           ],
           "Requests and results": [
             Jido.Harness.RunRequest,

--- a/test/jido_harness/escript_test.exs
+++ b/test/jido_harness/escript_test.exs
@@ -1,0 +1,108 @@
+defmodule Jido.Harness.EscriptTest do
+  use ExUnit.Case, async: false
+
+  import Bitwise
+
+  alias Jido.Harness.Error
+
+  @child_code """
+  [escript_path, cache_dir] = System.argv()
+  Application.put_env(:jido_harness, :process_manager, %{journal_dir: Path.join(cache_dir, "journals")})
+
+  with {:ok, helper_path} <-
+         Jido.Harness.Escript.bootstrap_erlexec(escript_path: escript_path, cache_dir: cache_dir),
+       {:ok, _applications} <- Application.ensure_all_started(:jido_harness) do
+    IO.puts("BOOTSTRAP_OK=" <> helper_path)
+  else
+    {:error, error} ->
+      IO.puts(:stderr, Exception.message(error))
+      System.halt(1)
+  end
+  """
+
+  setup do
+    directory =
+      Path.join(System.tmp_dir!(), "jido-harness-escript-test-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(directory)
+    on_exit(fn -> File.rm_rf!(directory) end)
+    {:ok, directory: directory}
+  end
+
+  test "a Mix escript extracts the current helper and starts jido_harness", %{directory: directory} do
+    architecture = :erlang.system_info(:system_architecture) |> List.to_string()
+    source = Path.join([:erlexec |> :code.priv_dir() |> List.to_string(), architecture, "exec-port"])
+    binary = File.read!(source)
+    {escript_path, environment} = build_escript(directory)
+    {output, 0} = System.cmd(escript_path, [], env: environment, stderr_to_stdout: true)
+    [helper_path] = Regex.run(~r/BOOTSTRAP_OK=(.+)/, output, capture: :all_but_first)
+
+    assert File.read!(helper_path) == binary
+    assert {:ok, stat} = File.stat(helper_path)
+    assert (stat.mode &&& 0o111) != 0
+    assert String.starts_with?(helper_path, Path.join([directory, "erlexec", architecture]))
+  end
+
+  test "rejects an archive without a helper for the current architecture", %{directory: directory} do
+    escript_path = Path.join(directory, "wrong-architecture.escript")
+
+    assert :ok =
+             :escript.create(String.to_charlist(escript_path), [
+               :shebang,
+               {:archive, [{~c"erlexec/priv/wrong-architecture/exec-port", "not-executable"}], []}
+             ])
+
+    {output, status} = run_child(escript_path, directory)
+    assert status == 1
+    assert output =~ "does not contain an erlexec helper for the current architecture"
+  end
+
+  test "rejects invalid options and calls after erlexec starts", %{directory: directory} do
+    assert {:error, %Error{category: :configuration, message: "escript bootstrap options must be a keyword list"}} =
+             Jido.Harness.Escript.bootstrap_erlexec(:invalid)
+
+    assert {:error, %Error{category: :configuration, message: "escript bootstrap options must be a keyword list"}} =
+             Jido.Harness.Escript.bootstrap_erlexec([:invalid])
+
+    assert {:error, %Error{category: :configuration, message: message}} =
+             Jido.Harness.Escript.bootstrap_erlexec(escript_path: "unused", cache_dir: directory)
+
+    assert message =~ "erlexec is already started"
+  end
+
+  defp run_child(escript_path, cache_dir) do
+    executable = System.find_executable("elixir") || raise "elixir executable is unavailable"
+
+    code_paths =
+      "_build/test/lib/*/ebin"
+      |> Path.expand(File.cwd!())
+      |> Path.wildcard()
+      |> Enum.flat_map(&["-pa", &1])
+
+    System.cmd(
+      executable,
+      code_paths ++ ["-e", @child_code, "--", escript_path, cache_dir],
+      env: [{"SHELL", System.get_env("SHELL") || "/bin/sh"}],
+      stderr_to_stdout: true
+    )
+  end
+
+  defp build_escript(directory) do
+    fixture = Path.expand("../../fixtures/escript_fixture", __DIR__)
+    escript_path = Path.join(directory, "jido-harness-escript-fixture")
+
+    environment = [
+      {"JIDO_HARNESS_ESCRIPT_CACHE_DIR", directory},
+      {"JIDO_HARNESS_ESCRIPT_PATH", escript_path},
+      {"MIX_BUILD_PATH", Path.expand("_build/test", File.cwd!())},
+      {"MIX_DEPS_PATH", Path.expand("deps", File.cwd!())},
+      {"MIX_ENV", "test"},
+      {"SHELL", System.get_env("SHELL") || "/bin/sh"}
+    ]
+
+    assert {_output, 0} = System.cmd("mix", ["deps.get"], cd: fixture, env: environment, stderr_to_stdout: true)
+    assert {_output, 0} = System.cmd("mix", ["escript.build"], cd: fixture, env: environment, stderr_to_stdout: true)
+
+    {escript_path, environment}
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -15,6 +15,8 @@
 - Use `Jido.Harness.Session` for harness-owned multi-turn conversations.
 - Use `Jido.Harness.Process` for direct structured executable-plus-argv
   processes.
+- In a Mix escript, call `Jido.Harness.Escript.bootstrap_erlexec/1` before
+  starting `:jido_harness`.
 - Keep `run_id`, `session_id`, `turn_id`, and `process_id` distinct from a
   provider's `provider_session_id`.
 


### PR DESCRIPTION
## Summary

- add a supported `Jido.Harness.Escript.bootstrap_erlexec/1` API
- extract only the architecture-specific `erlexec` helper into a private, content-specific cache path
- document the required Mix escript setup and startup order
- verify the flow with a real nested Mix escript fixture

## Validation

- `mix test` — 110 passed, 55 excluded
- `mix quality`
- `mix docs`
- `mix hex.build`

Closes #53.