### PR TITLE
test(grok): cover recovered tool errors

### DIFF
--- a/test/jido_harness/direct_cli_adapter_test.exs
+++ b/test/jido_harness/direct_cli_adapter_test.exs
@@ -52,4 +52,24 @@ defmodule Jido.Harness.DirectCLIAdapterTest do
     assert second.status == :completed
     assert second.provider_session_id == "gemini-fixture-session"
   end
+
+  test "Grok completes after a recovered tool error" do
+    assert {:ok, run_id} = Jido.Harness.Run.start(:grok, %{prompt: "fixture"})
+    assert {:ok, result} = Jido.Harness.Run.await(run_id, 5_000)
+
+    assert result.status == :completed
+    assert result.text == "grok-ok"
+    assert result.error == nil
+
+    assert {:ok, events} = Jido.Harness.Run.replay(run_id, limit: 100)
+
+    assert Enum.any?(events, fn
+             %{type: :tool_result, payload: %{"call_id" => "call-read", "is_error" => true}} -> true
+             _event -> false
+           end)
+
+    refute Enum.any?(events, &(&1.type == :run_failed))
+    assert Enum.count(events, &Jido.Harness.Event.run_terminal?/1) == 1
+    assert List.last(events).type == :run_completed
+  end
 end

--- a/test/support/fixtures/fake_stream_cli.exs
+++ b/test/support/fixtures/fake_stream_cli.exs
@@ -31,6 +31,10 @@ defmodule Jido.Harness.Fixture.StreamCLI do
 
   @grok [
     ~s({"type":"thought","data":"checking"}),
+    ~s({"type":"tool_call","toolCallId":"call-read","toolName":"read_file",) <>
+      ~s("rawInput":{"target_file":"missing.md"}}),
+    ~s({"type":"tool_call_update","toolCallId":"call-read","status":"failed",) <>
+      ~s("rawOutput":{"FileNotFound":"missing.md does not exist"}}),
     ~s({"type":"text","data":"grok-ok"}),
     ~s({"type":"usage","usage":{"input_tokens":2,"output_tokens":1}}),
     ~s({"type":"end","stopReason":"end_turn","sessionId":"grok-fixture-session",) <>


### PR DESCRIPTION
## Summary

- reproduce a failed Grok tool call followed by continued output and a successful terminal event
- assert that the failed tool remains a normalized `tool_result` event
- assert that the run completes without a `run_failed` terminal

The production behavior was corrected by the Grok 1.0 mapper in #54. This PR adds the missing end-to-end lifecycle regression that the Hancho burn-in exposed.

Closes #56.

## Verification

- `mix test test/jido_harness/adapter_test.exs test/jido_harness/direct_cli_adapter_test.exs`
- `mix quality`