### PR TITLE
W20 Phase 1: define structured output authority and child plan

### DIFF
--- a/.spec/planning/w20-codex-structured-output/README.md
+++ b/.spec/planning/w20-codex-structured-output/README.md
@@ -1,0 +1,88 @@
+---
+id: plan.jido_harness_w20_codex_structured_output
+status: planned
+intent: feature
+parent_plan: plan.w20_live_hr_company_brain_demonstration
+parent_phase: plan.w20_phase_02_codex_subscription_runtime
+frozen_default_sha: e41fc1651282469f2db4219a48d9f7feef1b0dbc
+authority_decision: docs/decisions/structured-output-schema-isolation.md
+---
+
+# W20 Codex Structured Output Child Plan
+
+This child plan delivers the generic schema-constrained finite-run capability
+required by W20 through Codex cached subscription authentication. It owns no HR
+prompt, provider-routing policy, classification meaning, answer policy, or
+direct OpenAI API path.
+
+- [ ] 1 Phase - Release schema-constrained Codex finite execution.
+
+  This phase maps Parent Phase 2 into one provider-owned release and remains
+  unauthorized until the W20 Phase 1 merged-default adoption receipt exists.
+
+  - [ ] 1.1 Section - Implement normalized structured-output requests and private schema lifecycle.
+
+    This section adds provider-neutral schema admission and harness-owned
+    staging without changing existing unstructured runs or sessions.
+
+    - [ ] 1.1.1 Task {#jido-w20-p01-s01-schema} [parent: w20-p02-s01-structured-output] - Add the bounded structured-output request contract.
+
+      This task makes schema data and isolation explicit normalized inputs and
+      rejects raw provider arguments, schema paths, credentials, and sessions.
+
+      - [ ] 1.1.1.1 Subtask {#jido-w20-1-1-1-1} - Add request schema, capability declarations, limits, validation, and typed unsupported-option errors.
+      - [ ] 1.1.1.2 Subtask {#jido-w20-1-1-1-2} - Add owner-only schema directory/file creation, deterministic serialization, redaction, and cleanup across every terminal path.
+
+  - [ ] 1.2 Section - Implement Codex argv mapping, isolation, and result validation.
+
+    This section translates the admitted request to one reviewed Codex CLI
+    execution while preserving actual enforced isolation and subscription auth.
+
+    - [ ] 1.2.1 Task {#jido-w20-p01-s02-codex} [parent: w20-p02-s01-structured-output] [after: {#jido-w20-p01-s01-schema}] - Implement the Codex structured-output adapter path.
+
+      This task uses executable-plus-argv construction and fails closed when
+      the installed Codex version cannot represent the exact contract.
+
+      - [ ] 1.2.1.1 Subtask {#jido-w20-1-2-1-1} - Map schema and isolation options, prohibit resume/session reuse, and preserve cached CLI authentication without reading credentials.
+      - [ ] 1.2.1.2 Subtask {#jido-w20-1-2-1-2} - Extract one terminal result under bounds, parse once, validate the schema, and normalize missing, duplicate, malformed, truncated, or invalid output.
+
+    - [ ] 1.2.2 Task {#jido-w20-p01-s02-safety} [parent: w20-p02-s02-isolation] [after: {#jido-w20-p01-s02-codex}] - Prove isolation, cancellation, and redaction behavior.
+
+      This task ensures concurrent and failed runs cannot retain or disclose
+      another run's schema, workspace, environment, output, or terminal state.
+
+      - [ ] 1.2.2.1 Subtask {#jido-w20-1-2-2-1} - Cover start failure, caller exit, timeout, cancellation, provider crash, cleanup failure, and concurrent-run isolation.
+      - [ ] 1.2.2.2 Subtask {#jido-w20-1-2-2-2} - Cover absent authentication and incompatible CLI behavior with no API, provider, or offline fallback.
+
+  - [ ] 1.3 Section - Freeze release compatibility and consumer handoff.
+
+    This section publishes one immutable capability identity for downstream
+    consumers without embedding any consumer prompt or domain schema.
+
+    - [ ] 1.3.1 Task {#jido-w20-p01-s03-release} [parent: w20-p02-s03-release-pin] [after: {#jido-w20-p01-s02-safety}] - Release and document the compatible structured-output seam.
+
+      This task separates non-billable readiness, optional live smoke, package
+      release identity, Codex CLI compatibility, and consumer pin evidence.
+
+      - [ ] 1.3.1.1 Subtask {#jido-w20-1-3-1-1} - Update adapter/security/provider documentation and capability discovery with exact compatibility and failure semantics.
+      - [ ] 1.3.1.2 Subtask {#jido-w20-1-3-1-2} - Publish one immutable release for Company Brain and MetaGraph Search to pin exactly.
+
+  - [ ] 1.4 Section - Integration Tests and provider release acceptance.
+
+    This final section proves the complete provider contract and is the only
+    local section permitted to make the release eligible for W20 consumers.
+
+    - [ ] 1.4.1 Task {#jido-w20-p01-integration} [parent: w20-p02-integration] [after: {#jido-w20-p01-s03-release}] - Run exact-default provider integration and publish the release receipt.
+
+      This task combines deterministic fake-CLI coverage with one deliberate
+      cached-subscription smoke after non-billable readiness succeeds.
+
+      - [ ] 1.4.1.1 Subtask {#jido-w20-1-4-1-1} - Run formatting, unit, property, lifecycle, concurrency, cancellation, redaction, compatibility, and full quality gates.
+      - [ ] 1.4.1.2 Subtask {#jido-w20-1-4-1-2} - Run one opt-in schema-valid Codex smoke, record only redacted identity evidence, and publish the immutable provider receipt.
+
+    Planned completion evidence: `receipt.jido_harness_w20_codex_structured_output`.
+
+## Current frontier
+
+No implementation section is authorized. This child plan becomes executable
+only after W20 Phase 1 accepts it on synchronized defaults.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Start with:
 - [Normalization and the data model](guides/normalization_and_data_model.md)
 - [Structured output execution contract](docs/structured_output_execution.md)
 - [Structured output schema-isolation decision](docs/decisions/structured-output-schema-isolation.md)
+- [W20 Codex structured-output child plan](.spec/planning/w20-codex-structured-output/README.md)
 
 Then follow the workflow guides for
 [one-shot requests](guides/one_shot_requests.md),

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Start with:
 - [Choosing a workflow](guides/choosing_a_workflow.md)
 - [Providers and capabilities](guides/providers.md)
 - [Normalization and the data model](guides/normalization_and_data_model.md)
+- [Structured output execution contract](docs/structured_output_execution.md)
+- [Structured output schema-isolation decision](docs/decisions/structured-output-schema-isolation.md)
 
 Then follow the workflow guides for
 [one-shot requests](guides/one_shot_requests.md),

--- a/docs/decisions/structured-output-schema-isolation.md
+++ b/docs/decisions/structured-output-schema-isolation.md
@@ -1,0 +1,86 @@
+# Structured Output Uses Harness-Owned Ephemeral Schema Isolation
+
+Status: accepted on 2026-08-23.
+
+This decision establishes the generic Jido.Harness authority for validating a
+caller-supplied output schema, staging it privately for a finite CLI run, and
+returning only schema-conformant structured output. It authorizes planning and
+contract work, not implementation or release availability.
+
+## Context
+
+Applications need coding-agent CLIs to return bounded machine-readable results
+without teaching each consumer provider-specific arguments, temporary-file
+lifecycle, output extraction, cancellation, or redaction. Codex supports a
+schema-constrained execution path while using an operator's existing cached
+subscription authentication. Jido.Harness already owns executable-plus-argv
+construction, supervised finite runs, provider normalization, timeouts, and
+process-group cancellation.
+
+## Decision
+
+1. Jido.Harness owns a provider-neutral structured-output request contract and
+   provider-specific translation. The caller supplies JSON Schema data and
+   bounds, never a schema path, shell fragment, raw provider argument, or
+   credential.
+2. The harness validates accepted schema shape and byte/depth/property limits
+   before process creation. Unsupported schema features and provider
+   capabilities fail before the CLI is started.
+3. Schema files live in a harness-created private directory, use restrictive
+   permissions, are addressed only by executable argv, and are removed after
+   success, failure, timeout, cancellation, or caller exit. Schema bodies and
+   private paths are excluded from telemetry and normalized errors.
+4. Structured runs are finite and ephemeral. A request cannot attach to or
+   resume a prior provider session, inherit another run's schema, or reuse a
+   previous structured result. Process supervision and cancellation retain the
+   existing Jido.Harness ownership rules.
+5. An isolation profile explicitly controls working directory, environment
+   inheritance, writable paths, provider configuration, and ambient project
+   instruction discovery. The harness rejects incompatible provider options
+   rather than weakening isolation silently.
+6. The Codex adapter maps the validated schema to the reviewed Codex CLI
+   interface and uses the CLI's existing cached subscription authentication.
+   Jido.Harness neither reads nor copies credential material and introduces no
+   OpenAI API, API key, Azure OpenAI, SDK, or alternate execution fallback.
+7. Successful provider termination is not structured-output success. The
+   harness locates the single terminal result, enforces byte limits, parses
+   JSON once, validates it against the accepted schema, and returns a typed
+   normalized result. Missing, duplicate, malformed, truncated, or invalid
+   output is a typed failure with no best-effort repair.
+8. Callers own prompts, product policy, provider selection, accepted schema
+   meaning, and validation beyond schema conformance. Jido.Harness owns no HR,
+   evidence, search, answer, classification, or corpus semantics and does not
+   route automatically to another provider.
+9. Readiness checks remain non-billable and distinct from opt-in live smokes.
+   Capability discovery must not advertise structured output until the exact
+   adapter behavior is implemented, tested, and released.
+
+## Consequences
+
+- Consumers share one reviewed lifecycle and failure contract instead of
+  implementing private Codex wrappers.
+- Cached subscription authentication stays in the Codex CLI boundary.
+- Schema conformance reduces output ambiguity without granting model output
+  product or authorization meaning.
+
+## Rejected alternatives
+
+### Let callers create schema files
+
+Rejected because callers would duplicate sensitive path, permission, cleanup,
+and cancellation behavior.
+
+### Treat valid JSON as schema-conformant
+
+Rejected because syntactic parsing does not enforce required fields, bounds,
+or additional-property policy.
+
+### Fall back to an API or another provider
+
+Rejected because a provider outage or incompatibility must remain visible and
+must not change authentication, billing, privacy, or model semantics.
+
+## Contract
+
+The normative planning contract is
+[`structured_output_execution.md`](../structured_output_execution.md).

--- a/docs/structured_output_execution.md
+++ b/docs/structured_output_execution.md
@@ -1,0 +1,106 @@
+# Structured Output Execution Contract
+
+This contract defines the planned provider-neutral request, ephemeral schema
+lifecycle, isolation, Codex subscription execution, normalized result, and
+failure behavior for finite schema-constrained Jido.Harness runs. It does not
+claim that the capability is implemented or advertised.
+
+## Request
+
+A structured-output request shall contain:
+
+- one registered provider selected explicitly by the caller;
+- a bounded prompt and ordinary finite-run limits;
+- one JSON Schema object with a stable caller-owned schema id;
+- an explicit isolation profile;
+- timeout, cancellation, output-byte, and event-retention ceilings; and
+- provider options already advertised as compatible with structured output.
+
+It shall reject schema paths, raw CLI arguments, shell text, credentials,
+provider endpoints, unregistered adapters, session ids, resume ids, and
+unknown or incompatible options.
+
+## Schema admission and lifecycle
+
+Before process creation, the harness shall validate that the schema is a JSON
+object and enforce configured byte, nesting, property, enum, and combinator
+ceilings. Admission shall reject unsupported keywords when the selected
+provider cannot represent them exactly.
+
+The admitted schema shall be serialized deterministically into a newly created
+private harness directory. The directory and file shall use owner-only access,
+shall not be consumer-selected, and shall not be reused across runs. Cleanup
+shall execute after every terminal path, including start failure, caller exit,
+timeout, cancellation, provider crash, malformed output, and validation
+failure. Telemetry, errors, events, and results shall exclude schema bodies,
+private paths, environment values, and credential locations.
+
+## Isolation
+
+The isolation profile shall explicitly resolve:
+
+- an existing working directory or a harness-owned empty workspace;
+- whether project instruction discovery is allowed;
+- the exact writable workspace policy;
+- a minimal environment inheritance policy compatible with the provider's
+  installed CLI and cached authentication;
+- network and sandbox options the adapter can represent; and
+- whether provider configuration outside the request is admitted.
+
+If the provider cannot honor a requested isolation property, the run shall be
+rejected. The harness shall never report stronger isolation than the launched
+argv and environment actually enforce.
+
+## Codex subscription behavior
+
+For provider `:codex`, the adapter shall use executable-plus-argv construction
+for the reviewed Codex schema option and an ephemeral finite execution. The
+Codex CLI resolves the operator's cached subscription authentication through
+its ordinary mechanism; the harness shall not read, export, copy, log, or
+translate credential material.
+
+No direct OpenAI API, API key, Azure OpenAI, SDK call, provider substitution,
+offline generator, or caller-owned Codex launcher is part of this contract.
+Missing CLI, missing cached authentication, readiness failure, unsupported CLI
+version, or provider outage shall return a typed failure.
+
+## Result validation
+
+The adapter shall identify exactly one terminal structured result under a hard
+byte ceiling, decode JSON once, and validate it against the admitted schema.
+Success shall include the schema id, provider, normalized terminal status, and
+validated value without returning the private schema path.
+
+The contract shall distinguish at least invalid request, unsupported schema,
+unsupported capability, isolation unavailable, executable missing,
+authentication unavailable, start failure, timeout, cancellation, provider
+failure, output missing, output duplicate, output truncated, malformed JSON,
+schema mismatch, and cleanup failure. Cleanup failure shall remain observable
+without disclosing private paths.
+
+## Ownership and compatibility
+
+Jido.Harness owns request normalization, schema admission and staging,
+provider translation, supervision, terminal output extraction, schema
+validation, cleanup, normalized failures, and redacted telemetry. Consumers
+own prompts, provider policy, domain schemas, post-schema semantic validation,
+and decisions to accept or reject a result.
+
+The initial contract is additive. Existing unstructured finite runs and
+sessions retain their behavior. Structured-output capability is advertised
+only by an exact released adapter version and shall fail closed across unknown
+or incompatible Codex CLI versions.
+
+## Acceptance scenarios
+
+1. A valid bounded schema and compatible Codex installation produce one
+   schema-valid result and leave no staged schema artifact.
+2. Malformed, oversized, unsupported, missing, duplicate, or nonconformant
+   output fails without best-effort repair.
+3. Timeout and cancellation terminate the process group and remove the private
+   schema directory.
+4. An isolation request the adapter cannot enforce is rejected before launch.
+5. Missing cached subscription authentication produces an authentication
+   failure and never activates an API or provider fallback.
+6. Concurrent structured runs cannot observe or reuse each other's schema,
+   workspace, result, environment, or terminal state.


### PR DESCRIPTION
Defines the generic Codex cached-subscription structured-output and isolation contract, then adds its hierarchical W20 provider plan. No product prompts, direct OpenAI API path, or provider fallback is introduced.\n\nValidation: mix quality; git diff --check.