### PR TITLE
W20 Phase 2: release structured Codex output

### DIFF
--- a/.spec/evidence/w20-codex-structured-output-receipt.md
+++ b/.spec/evidence/w20-codex-structured-output-receipt.md
@@ -1,0 +1,47 @@
+---
+id: receipt.jido_harness_w20_codex_structured_output
+status: accepted
+release: 2.1.0-rc.2
+release_identity: git_commit_containing_this_receipt
+minimum_codex_cli: 0.144.6
+authentication: cached_subscription
+provider: codex
+capability: structured_output
+---
+
+# W20 Codex Structured Output Acceptance Receipt
+
+Jido.Harness `2.1.0-rc.2` is the accepted W20 consumer handoff. The exact
+40-character commit containing this receipt and its release manifest is the
+only compatible pin; consumer lockfiles and the parent adoption receipt record
+that immutable value after this section commit exists.
+
+## Deterministic acceptance
+
+- `mix test`: 133 tests, 0 failures, 55 excluded.
+- `mix quality`: passed formatting, compile warnings-as-errors, static analysis,
+  type analysis, and documentation validation.
+- Fake-CLI coverage exercises schema staging and cleanup, exact argv and
+  environment isolation, result validation, cancellation, timeout, caller
+  exit, process failure, incompatible CLI, missing authentication, concurrent
+  runs, redaction, and the absence of API/provider/offline fallbacks.
+- Admission accepts the governed 128-concept enum schema within a bounded
+  aggregate ceiling of 256 values and rejects 257 values.
+- Admission rejects schema combinators before provider execution after the
+  compatible CLI rejected the attempted `anyOf` form during consumer smoke.
+
+## Deliberate live smoke
+
+After non-billable readiness reported installed, compatible, authenticated,
+and `structured_output?: true`, one cached-subscription run completed with
+Codex CLI `0.144.6`. It used the fixed ephemeral read-only profile and the
+governed 128-concept enum shape, returned one schema-valid result under schema
+id `w20.release.smoke.v1`, exposed no provider session id, and required no API
+key. No prompt, model output, credential, private path, or token detail is
+retained in this receipt.
+
+## Disposition
+
+Release candidate `2.1.0-rc.1` is superseded. Release candidate `2.1.0-rc.2`
+is accepted for exact consumer pinning, subject to the consumer repositories'
+own fail-closed integration acceptance.

--- a/.spec/planning/w20-codex-structured-output/README.md
+++ b/.spec/planning/w20-codex-structured-output/README.md
@@ -33,26 +33,26 @@ direct OpenAI API path.
       - [x] 1.1.1.1 Subtask {#jido-w20-1-1-1-1} - Add request schema, capability declarations, limits, validation, and typed unsupported-option errors.
       - [x] 1.1.1.2 Subtask {#jido-w20-1-1-1-2} - Add owner-only schema directory/file creation, deterministic serialization, redaction, and cleanup across every terminal path.
 
-  - [ ] 1.2 Section - Implement Codex argv mapping, isolation, and result validation.
+  - [x] 1.2 Section - Implement Codex argv mapping, isolation, and result validation.
 
     This section translates the admitted request to one reviewed Codex CLI
     execution while preserving actual enforced isolation and subscription auth.
 
-    - [ ] 1.2.1 Task {#jido-w20-p01-s02-codex} [parent: w20-p02-s01-structured-output] [after: {#jido-w20-p01-s01-schema}] - Implement the Codex structured-output adapter path.
+    - [x] 1.2.1 Task {#jido-w20-p01-s02-codex} [parent: w20-p02-s01-structured-output] [after: {#jido-w20-p01-s01-schema}] - Implement the Codex structured-output adapter path.
 
       This task uses executable-plus-argv construction and fails closed when
       the installed Codex version cannot represent the exact contract.
 
-      - [ ] 1.2.1.1 Subtask {#jido-w20-1-2-1-1} - Map schema and isolation options, prohibit resume/session reuse, and preserve cached CLI authentication without reading credentials.
-      - [ ] 1.2.1.2 Subtask {#jido-w20-1-2-1-2} - Extract one terminal result under bounds, parse once, validate the schema, and normalize missing, duplicate, malformed, truncated, or invalid output.
+      - [x] 1.2.1.1 Subtask {#jido-w20-1-2-1-1} - Map schema and isolation options, prohibit resume/session reuse, and preserve cached CLI authentication without reading credentials.
+      - [x] 1.2.1.2 Subtask {#jido-w20-1-2-1-2} - Extract one terminal result under bounds, parse once, validate the schema, and normalize missing, duplicate, malformed, truncated, or invalid output.
 
-    - [ ] 1.2.2 Task {#jido-w20-p01-s02-safety} [parent: w20-p02-s02-isolation] [after: {#jido-w20-p01-s02-codex}] - Prove isolation, cancellation, and redaction behavior.
+    - [x] 1.2.2 Task {#jido-w20-p01-s02-safety} [parent: w20-p02-s02-isolation] [after: {#jido-w20-p01-s02-codex}] - Prove isolation, cancellation, and redaction behavior.
 
       This task ensures concurrent and failed runs cannot retain or disclose
       another run's schema, workspace, environment, output, or terminal state.
 
-      - [ ] 1.2.2.1 Subtask {#jido-w20-1-2-2-1} - Cover start failure, caller exit, timeout, cancellation, provider crash, cleanup failure, and concurrent-run isolation.
-      - [ ] 1.2.2.2 Subtask {#jido-w20-1-2-2-2} - Cover absent authentication and incompatible CLI behavior with no API, provider, or offline fallback.
+      - [x] 1.2.2.1 Subtask {#jido-w20-1-2-2-1} - Cover start failure, caller exit, timeout, cancellation, provider crash, cleanup failure, and concurrent-run isolation.
+      - [x] 1.2.2.2 Subtask {#jido-w20-1-2-2-2} - Cover absent authentication and incompatible CLI behavior with no API, provider, or offline fallback.
 
   - [ ] 1.3 Section - Freeze release compatibility and consumer handoff.
 
@@ -84,5 +84,5 @@ direct OpenAI API path.
 
 ## Current frontier
 
-Section 1.1 is complete. Section 1.2 is the active implementation frontier;
-release publication and live-provider acceptance remain pending.
+Sections 1.1 and 1.2 are complete. Section 1.3 is the active release frontier;
+provider release acceptance remains pending.

--- a/.spec/planning/w20-codex-structured-output/README.md
+++ b/.spec/planning/w20-codex-structured-output/README.md
@@ -54,18 +54,18 @@ direct OpenAI API path.
       - [x] 1.2.2.1 Subtask {#jido-w20-1-2-2-1} - Cover start failure, caller exit, timeout, cancellation, provider crash, cleanup failure, and concurrent-run isolation.
       - [x] 1.2.2.2 Subtask {#jido-w20-1-2-2-2} - Cover absent authentication and incompatible CLI behavior with no API, provider, or offline fallback.
 
-  - [ ] 1.3 Section - Freeze release compatibility and consumer handoff.
+  - [x] 1.3 Section - Freeze release compatibility and consumer handoff.
 
     This section publishes one immutable capability identity for downstream
     consumers without embedding any consumer prompt or domain schema.
 
-    - [ ] 1.3.1 Task {#jido-w20-p01-s03-release} [parent: w20-p02-s03-release-pin] [after: {#jido-w20-p01-s02-safety}] - Release and document the compatible structured-output seam.
+    - [x] 1.3.1 Task {#jido-w20-p01-s03-release} [parent: w20-p02-s03-release-pin] [after: {#jido-w20-p01-s02-safety}] - Release and document the compatible structured-output seam.
 
       This task separates non-billable readiness, optional live smoke, package
       release identity, Codex CLI compatibility, and consumer pin evidence.
 
-      - [ ] 1.3.1.1 Subtask {#jido-w20-1-3-1-1} - Update adapter/security/provider documentation and capability discovery with exact compatibility and failure semantics.
-      - [ ] 1.3.1.2 Subtask {#jido-w20-1-3-1-2} - Publish one immutable release for Company Brain and MetaGraph Search to pin exactly.
+      - [x] 1.3.1.1 Subtask {#jido-w20-1-3-1-1} - Update adapter/security/provider documentation and capability discovery with exact compatibility and failure semantics.
+      - [x] 1.3.1.2 Subtask {#jido-w20-1-3-1-2} - Publish one immutable release for Company Brain and MetaGraph Search to pin exactly.
 
   - [ ] 1.4 Section - Integration Tests and provider release acceptance.
 
@@ -84,5 +84,5 @@ direct OpenAI API path.
 
 ## Current frontier
 
-Sections 1.1 and 1.2 are complete. Section 1.3 is the active release frontier;
-provider release acceptance remains pending.
+Sections 1.1 through 1.3 are complete. Section 1.4 provider release acceptance
+is the active frontier.

--- a/.spec/planning/w20-codex-structured-output/README.md
+++ b/.spec/planning/w20-codex-structured-output/README.md
@@ -1,6 +1,6 @@
 ---
 id: plan.jido_harness_w20_codex_structured_output
-status: active
+status: completed
 intent: feature
 parent_plan: plan.w20_live_hr_company_brain_demonstration
 parent_phase: plan.w20_phase_02_codex_subscription_runtime
@@ -15,7 +15,7 @@ required by W20 through Codex cached subscription authentication. It owns no HR
 prompt, provider-routing policy, classification meaning, answer policy, or
 direct OpenAI API path.
 
-- [ ] 1 Phase - Release schema-constrained Codex finite execution.
+- [x] 1 Phase - Release schema-constrained Codex finite execution.
 
   This phase maps Parent Phase 2 into one provider-owned release and remains
   authorized by the W20 Phase 1 merged-default adoption receipt.
@@ -67,22 +67,22 @@ direct OpenAI API path.
       - [x] 1.3.1.1 Subtask {#jido-w20-1-3-1-1} - Update adapter/security/provider documentation and capability discovery with exact compatibility and failure semantics.
       - [x] 1.3.1.2 Subtask {#jido-w20-1-3-1-2} - Publish one immutable release for Company Brain and MetaGraph Search to pin exactly.
 
-  - [ ] 1.4 Section - Integration Tests and provider release acceptance.
+  - [x] 1.4 Section - Integration Tests and provider release acceptance.
 
     This final section proves the complete provider contract and is the only
     local section permitted to make the release eligible for W20 consumers.
 
-    - [ ] 1.4.1 Task {#jido-w20-p01-integration} [parent: w20-p02-integration] [after: {#jido-w20-p01-s03-release}] - Run exact-default provider integration and publish the release receipt.
+    - [x] 1.4.1 Task {#jido-w20-p01-integration} [parent: w20-p02-integration] [after: {#jido-w20-p01-s03-release}] - Run exact-default provider integration and publish the release receipt.
 
       This task combines deterministic fake-CLI coverage with one deliberate
       cached-subscription smoke after non-billable readiness succeeds.
 
-      - [ ] 1.4.1.1 Subtask {#jido-w20-1-4-1-1} - Run formatting, unit, property, lifecycle, concurrency, cancellation, redaction, compatibility, and full quality gates.
-      - [ ] 1.4.1.2 Subtask {#jido-w20-1-4-1-2} - Run one opt-in schema-valid Codex smoke, record only redacted identity evidence, and publish the immutable provider receipt.
+      - [x] 1.4.1.1 Subtask {#jido-w20-1-4-1-1} - Run formatting, unit, property, lifecycle, concurrency, cancellation, redaction, compatibility, and full quality gates.
+      - [x] 1.4.1.2 Subtask {#jido-w20-1-4-1-2} - Run one opt-in schema-valid Codex smoke, record only redacted identity evidence, and publish the immutable provider receipt.
 
     Planned completion evidence: `receipt.jido_harness_w20_codex_structured_output`.
 
 ## Current frontier
 
-Sections 1.1 through 1.3 are complete. Section 1.4 provider release acceptance
-is the active frontier.
+Phase 1 is complete. Jido.Harness `2.1.0-rc.2` is accepted for exact consumer
+pinning through `receipt.jido_harness_w20_codex_structured_output`.

--- a/.spec/planning/w20-codex-structured-output/README.md
+++ b/.spec/planning/w20-codex-structured-output/README.md
@@ -1,6 +1,6 @@
 ---
 id: plan.jido_harness_w20_codex_structured_output
-status: planned
+status: active
 intent: feature
 parent_plan: plan.w20_live_hr_company_brain_demonstration
 parent_phase: plan.w20_phase_02_codex_subscription_runtime
@@ -18,20 +18,20 @@ direct OpenAI API path.
 - [ ] 1 Phase - Release schema-constrained Codex finite execution.
 
   This phase maps Parent Phase 2 into one provider-owned release and remains
-  unauthorized until the W20 Phase 1 merged-default adoption receipt exists.
+  authorized by the W20 Phase 1 merged-default adoption receipt.
 
-  - [ ] 1.1 Section - Implement normalized structured-output requests and private schema lifecycle.
+  - [x] 1.1 Section - Implement normalized structured-output requests and private schema lifecycle.
 
     This section adds provider-neutral schema admission and harness-owned
     staging without changing existing unstructured runs or sessions.
 
-    - [ ] 1.1.1 Task {#jido-w20-p01-s01-schema} [parent: w20-p02-s01-structured-output] - Add the bounded structured-output request contract.
+    - [x] 1.1.1 Task {#jido-w20-p01-s01-schema} [parent: w20-p02-s01-structured-output] - Add the bounded structured-output request contract.
 
       This task makes schema data and isolation explicit normalized inputs and
       rejects raw provider arguments, schema paths, credentials, and sessions.
 
-      - [ ] 1.1.1.1 Subtask {#jido-w20-1-1-1-1} - Add request schema, capability declarations, limits, validation, and typed unsupported-option errors.
-      - [ ] 1.1.1.2 Subtask {#jido-w20-1-1-1-2} - Add owner-only schema directory/file creation, deterministic serialization, redaction, and cleanup across every terminal path.
+      - [x] 1.1.1.1 Subtask {#jido-w20-1-1-1-1} - Add request schema, capability declarations, limits, validation, and typed unsupported-option errors.
+      - [x] 1.1.1.2 Subtask {#jido-w20-1-1-1-2} - Add owner-only schema directory/file creation, deterministic serialization, redaction, and cleanup across every terminal path.
 
   - [ ] 1.2 Section - Implement Codex argv mapping, isolation, and result validation.
 
@@ -84,5 +84,5 @@ direct OpenAI API path.
 
 ## Current frontier
 
-No implementation section is authorized. This child plan becomes executable
-only after W20 Phase 1 accepts it on synchronized defaults.
+Section 1.1 is complete. Section 1.2 is the active implementation frontier;
+release publication and live-provider acceptance remain pending.

--- a/.spec/releases/w20-codex-structured-output-2.1.0-rc.1.md
+++ b/.spec/releases/w20-codex-structured-output-2.1.0-rc.1.md
@@ -1,0 +1,37 @@
+---
+id: release.jido_harness_w20_codex_structured_output_2_1_0_rc_1
+status: release_candidate
+version: 2.1.0-rc.1
+minimum_codex_cli: 0.144.6
+capability: structured_output
+provider: codex
+authentication: cached_subscription
+---
+
+# W20 Codex Structured Output Release Candidate
+
+This release candidate is the immutable consumer handoff for W20 Phase 2.
+Consumers must pin the 40-character Git commit containing this manifest; path,
+branch, floating-version, and direct OpenAI API dependencies are incompatible.
+
+## Capability boundary
+
+- finite `Jido.Harness.run` and detached `Jido.Harness.Run` execution only;
+- one bounded JSON Schema object and caller-owned schema id;
+- fixed `:ephemeral_read_only` isolation with private schema/workspace cleanup;
+- Codex CLI cached subscription authentication only;
+- one parsed and schema-validated result in `RunResult.structured_output`;
+- non-billable readiness distinct from an explicit live smoke; and
+- no session, resume, raw argv, credential, endpoint, API, SDK, provider, or
+  offline fallback.
+
+## Consumer migration
+
+1. Pin the exact release-candidate commit and verify version
+   `2.1.0-rc.1` at compile time.
+2. Require `Jido.Harness.status(:codex)` to report installed, compatible,
+   authenticated, and `structured_output?: true`.
+3. Supply domain prompts and JSON Schemas through normalized request data.
+4. Treat every non-completed result and absent `structured_output` value as a
+   closed failure; do not repair or reroute.
+5. Keep optional live subscription smokes behind an explicit operator opt-in.

--- a/.spec/releases/w20-codex-structured-output-2.1.0-rc.1.md
+++ b/.spec/releases/w20-codex-structured-output-2.1.0-rc.1.md
@@ -1,6 +1,6 @@
 ---
 id: release.jido_harness_w20_codex_structured_output_2_1_0_rc_1
-status: release_candidate
+status: superseded
 version: 2.1.0-rc.1
 minimum_codex_cli: 0.144.6
 capability: structured_output
@@ -9,6 +9,10 @@ authentication: cached_subscription
 ---
 
 # W20 Codex Structured Output Release Candidate
+
+This candidate was superseded by `2.1.0-rc.2` during integration because the
+128-concept consumer schema requires a larger bounded aggregate enum ceiling.
+It is not an accepted consumer pin.
 
 This release candidate is the immutable consumer handoff for W20 Phase 2.
 Consumers must pin the 40-character Git commit containing this manifest; path,

--- a/.spec/releases/w20-codex-structured-output-2.1.0-rc.2.md
+++ b/.spec/releases/w20-codex-structured-output-2.1.0-rc.2.md
@@ -1,0 +1,29 @@
+---
+id: release.jido_harness_w20_codex_structured_output_2_1_0_rc_2
+status: accepted_release_candidate
+version: 2.1.0-rc.2
+minimum_codex_cli: 0.144.6
+capability: structured_output
+provider: codex
+authentication: cached_subscription
+maximum_aggregate_enum_values: 256
+---
+
+# W20 Codex Structured Output Accepted Release Candidate
+
+This candidate supersedes rc.1 and is the sole accepted consumer handoff for
+W20 Phase 2. Consumers must pin the 40-character Git commit containing this
+manifest; path, branch, floating-version, and direct OpenAI API dependencies
+are incompatible.
+
+The release supports finite and detached structured runs through the fixed
+`:ephemeral_read_only` profile, private schema/workspace cleanup, cached Codex
+subscription authentication, typed failures, and one schema-validated result.
+It supports at most 256 aggregate enum members so the governed 128-concept
+classification schema can retain exact concept membership plus bounded control
+enums. Schema combinators are rejected during Harness admission because the
+compatible Codex CLI cannot represent the attempted form exactly.
+
+Consumers must verify version `2.1.0-rc.2`, minimum Codex CLI `0.144.6`, and
+`structured_output?: true`; every unavailable or invalid result fails closed
+without API, provider, offline, or session fallback.

--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -67,6 +67,11 @@ Finite request precedence is:
 2. configured `provider_config[provider].request_defaults`;
 3. explicit request values.
 
+For Codex structured runs, provider-config environment entries and request
+defaults cannot weaken the fixed isolation profile. `cli_path` may select the
+installed Codex executable; all behavior remains represented by normalized
+request fields and the reviewed adapter argv.
+
 ## `:process_manager`
 
 ```elixir

--- a/docs/event_reference.md
+++ b/docs/event_reference.md
@@ -49,6 +49,7 @@ Every accepted turn receives exactly one turn-terminal event.
 | --- | --- |
 | `:output_text_delta` | Incremental assistant text |
 | `:output_text_final` | Provider-declared final assistant text |
+| `:structured_output` | Schema id and validated JSON value from a successful structured run |
 | `:thinking_delta` | Incremental reasoning/thinking data |
 | `:command_output_delta` | Incremental output from a provider command/tool |
 | `:tool_call` | Normalized tool invocation |
@@ -59,6 +60,11 @@ Every accepted turn receives exactly one turn-terminal event.
 
 These events are capability-dependent. A provider that cannot supply a
 canonical value does not fabricate it.
+
+For structured runs, `:structured_output` is emitted only after the single
+terminal text has passed the byte ceiling, JSON decoding, and schema
+validation. Its payload is `%{"schema_id" => id, "value" => value}`. Private
+schema paths and resumable provider-session identifiers are omitted.
 
 ## Interaction events
 

--- a/docs/migration_v2.md
+++ b/docs/migration_v2.md
@@ -102,3 +102,16 @@ existing `cwd`. For direct executable ownership, use a structured
 `Jido.Harness.ProcessSpec` with executable plus argv.
 
 `jido_shell` remains a separate package and is not part of v2 execution.
+
+## Adopt 2.1 structured output explicitly
+
+Jido.Harness `2.1.0-rc.1` adds an optional `structured_output` field to finite
+`RunRequest` values and a nullable `structured_output` field to `RunResult`.
+Existing unstructured runs and sessions do not change.
+
+Consumers adopting the release candidate should pin its immutable Git commit,
+require Codex CLI `0.144.6` or newer, check
+`capabilities.structured_output?`, and call `Jido.Harness.status(:codex)` before
+an optional live smoke. Structured requests cannot use a provider session id,
+resume behavior, request environment, attachments, extra directories, or a
+writable sandbox.

--- a/docs/migration_v2.md
+++ b/docs/migration_v2.md
@@ -105,7 +105,7 @@ existing `cwd`. For direct executable ownership, use a structured
 
 ## Adopt 2.1 structured output explicitly
 
-Jido.Harness `2.1.0-rc.1` adds an optional `structured_output` field to finite
+Jido.Harness `2.1.0-rc.2` adds an optional `structured_output` field to finite
 `RunRequest` values and a nullable `structured_output` field to `RunResult`.
 Existing unstructured runs and sessions do not change.
 

--- a/docs/structured_output_execution.md
+++ b/docs/structured_output_execution.md
@@ -1,9 +1,40 @@
 # Structured Output Execution Contract
 
-This contract defines the planned provider-neutral request, ephemeral schema
+This contract defines the implemented provider-neutral request, ephemeral schema
 lifecycle, isolation, Codex subscription execution, normalized result, and
-failure behavior for finite schema-constrained Jido.Harness runs. It does not
-claim that the capability is implemented or advertised.
+failure behavior for finite schema-constrained Jido.Harness runs. The initial
+capability is advertised by Jido.Harness `2.1.0-rc.1` for Codex CLI `0.144.6`
+or newer.
+
+## Example
+
+```elixir
+schema = %{
+  "type" => "object",
+  "properties" => %{
+    "department" => %{"type" => "string", "enum" => ["people", "finance"]},
+    "confidence" => %{"type" => "number", "minimum" => 0, "maximum" => 1}
+  },
+  "required" => ["department", "confidence"],
+  "additionalProperties" => false
+}
+
+{:ok, %Jido.Harness.RunResult{status: :completed} = result} =
+  Jido.Harness.run(:codex, %{
+    prompt: "Classify this bounded input.",
+    structured_output: %{
+      schema_id: "classification.v1",
+      schema: schema,
+      max_output_bytes: 16_384
+    }
+  })
+
+%{"schema_id" => "classification.v1", "value" => value} =
+  result.structured_output
+```
+
+`structured_output.isolation` defaults to the only supported value,
+`:ephemeral_read_only`. Callers supply schema data, never a schema path.
 
 ## Request
 

--- a/docs/structured_output_execution.md
+++ b/docs/structured_output_execution.md
@@ -3,7 +3,7 @@
 This contract defines the implemented provider-neutral request, ephemeral schema
 lifecycle, isolation, Codex subscription execution, normalized result, and
 failure behavior for finite schema-constrained Jido.Harness runs. The initial
-capability is advertised by Jido.Harness `2.1.0-rc.1` for Codex CLI `0.144.6`
+capability is advertised by Jido.Harness `2.1.0-rc.2` for Codex CLI `0.144.6`
 or newer.
 
 ## Example
@@ -54,9 +54,9 @@ unknown or incompatible options.
 ## Schema admission and lifecycle
 
 Before process creation, the harness shall validate that the schema is a JSON
-object and enforce configured byte, nesting, property, enum, and combinator
-ceilings. Admission shall reject unsupported keywords when the selected
-provider cannot represent them exactly.
+object and enforce configured byte, nesting, property, and enum ceilings.
+Schema combinators and other unsupported keywords shall be rejected when the
+selected provider cannot represent them exactly.
 
 The admitted schema shall be serialized deterministically into a newly created
 private harness directory. The directory and file shall use owner-only access,

--- a/guides/providers.md
+++ b/guides/providers.md
@@ -84,7 +84,7 @@ specifications. Codex readiness verifies the CLI compatibility boundary and
 cached subscription login without making a billable model request or accepting
 an API key as a substitute.
 
-Codex structured output requires Jido.Harness `2.1.0-rc.1` or later in the
+Codex structured output requires Jido.Harness `2.1.0-rc.2` or later in the
 2.1 line and `codex-cli` `0.144.6` or later. It is a finite-run capability, not
 an interactive-session capability. See the
 [structured-output contract](../docs/structured_output_execution.md).

--- a/guides/providers.md
+++ b/guides/providers.md
@@ -35,17 +35,17 @@ All built-in providers stream normalized events and support process-group
 cancellation. Capability flags describe whether a provider protocol supplies a
 canonical form of optional data.
 
-| Provider | Thinking | Tool events | Usage | Structured file-change events |
-| --- | --- | --- | --- | --- |
-| Amp | yes | yes | yes | no |
-| Claude | yes | yes | yes | no |
-| Codex | yes | yes | yes | yes |
-| Gemini | no | yes | yes | no |
-| Grok | yes | yes | yes | no |
-| Kimi | no | yes | no | no |
-| OpenCode | no | no | no | no |
-| Pi | yes | yes | yes | no |
-| Z.AI | yes | yes | yes | no |
+| Provider | Thinking | Tool events | Usage | File changes | Structured output |
+| --- | --- | --- | --- | --- | --- |
+| Amp | yes | yes | yes | no | no |
+| Claude | yes | yes | yes | no | no |
+| Codex | yes | yes | yes | yes | yes |
+| Gemini | no | yes | yes | no | no |
+| Grok | yes | yes | yes | no | no |
+| Kimi | no | yes | no | no | no |
+| OpenCode | no | no | no | no | no |
+| Pi | yes | yes | yes | no | no |
+| Z.AI | yes | yes | yes | no | no |
 
 "No structured file-change events" does not mean a provider cannot modify
 files. It means its current adapter does not claim a reliable canonical
@@ -80,7 +80,14 @@ Jido.Harness.ProviderStatus.ready?(status)
 
 `ProviderStatus` includes installation, compatibility, authentication,
 readiness, version, executable, finite-run capabilities, and session transport
-specifications. Authentication may be `:unknown` for cached-login CLIs.
+specifications. Codex readiness verifies the CLI compatibility boundary and
+cached subscription login without making a billable model request or accepting
+an API key as a substitute.
+
+Codex structured output requires Jido.Harness `2.1.0-rc.1` or later in the
+2.1 line and `codex-cli` `0.144.6` or later. It is a finite-run capability, not
+an interactive-session capability. See the
+[structured-output contract](../docs/structured_output_execution.md).
 
 The equivalent operator command is:
 

--- a/guides/security.md
+++ b/guides/security.md
@@ -52,6 +52,26 @@ preserved by finite runs, managed-session turns, ACP sessions, and Pi RPC
 sessions; it prevents ambient host variables from reaching provider
 descendants.
 
+Codex structured runs always replace the child environment with a minimal
+allowlist containing only executable, cached-login location, temporary-file,
+locale, and TLS-certificate variables. API-key and access-token variables are
+not inherited. The CLI reads its ordinary cached subscription authentication;
+the harness does not inspect or copy the credential files.
+
+## Structured-output isolation
+
+Selecting `structured_output` activates the fixed `:ephemeral_read_only`
+profile. Harness creates a fresh empty working directory, stages the JSON
+Schema in a separate owner-only path, disables session persistence, ignores
+user config and project rules, disables project instruction discovery, uses a
+read-only Codex sandbox with approval policy `never`, and removes the workspace
+after every terminal path.
+
+Structured requests reject session or resume identifiers, extra directories,
+attachments, request environment entries, writable or unrestricted sandboxes,
+interactive approval modes, and provider behavior switches. There is no API,
+alternate-provider, offline, or session fallback.
+
 ## Redaction
 
 Jido.Harness redacts structured sensitive fields, bearer credentials, and

--- a/lib/jido_harness.ex
+++ b/lib/jido_harness.ex
@@ -34,7 +34,7 @@ defmodule Jido.Harness do
 
   alias Jido.Harness.{AdapterSpec, Error, ProviderStatus, Registry, Run, RunRequest, RunResult, Validation}
 
-  @version "2.0.0"
+  @version "2.1.0-rc.1"
 
   @type provider :: atom()
   @type request :: String.t() | map() | keyword() | RunRequest.t()

--- a/lib/jido_harness.ex
+++ b/lib/jido_harness.ex
@@ -34,7 +34,7 @@ defmodule Jido.Harness do
 
   alias Jido.Harness.{AdapterSpec, Error, ProviderStatus, Registry, Run, RunRequest, RunResult, Validation}
 
-  @version "2.1.0-rc.1"
+  @version "2.1.0-rc.2"
 
   @type provider :: atom()
   @type request :: String.t() | map() | keyword() | RunRequest.t()

--- a/lib/jido_harness/adapters/codex.ex
+++ b/lib/jido_harness/adapters/codex.ex
@@ -3,7 +3,9 @@ defmodule Jido.Harness.Adapters.Codex do
   @behaviour Jido.Harness.Adapter
 
   alias Jido.Harness.{AdapterSpec, Adapters.CLIArgs, Adapters.CLIMapper, Adapters.CLIStream}
-  alias Jido.Harness.{Adapters.Helpers, Capabilities, Error, RunRequest}
+  alias Jido.Harness.{Adapters.CodexCompatibility, Adapters.CodexEnvironment, Adapters.Helpers}
+  alias Jido.Harness.{Capabilities, Error, RunRequest}
+  alias Jido.Harness.StructuredOutput.{SchemaWorkspace, Stream, WorkspaceGuard}
 
   @provider_options [
     :cli_path,
@@ -55,24 +57,51 @@ defmodule Jido.Harness.Adapters.Codex do
     options = Helpers.provider_options(request.provider_options, @provider_options)
 
     with :ok <- validate_options(request, options),
-         {:ok, argv} <- build_argv(request, options) do
-      request = %{request | env: Helpers.merge_env(request, context.config)}
-      executable = options[:cli_path] || Helpers.cli_path(context.config, spec().executable)
-      CLIStream.run(:codex, request, context, executable, argv, &CLIMapper.codex/1)
+         executable = options[:cli_path] || Helpers.cli_path(context.config, spec().executable) do
+      if request.structured_output do
+        run_structured(request, context, executable, options)
+      else
+        with {:ok, argv} <- build_argv(request, options) do
+          request = %{request | env: Helpers.merge_env(request, context.config)}
+          CLIStream.run(:codex, request, context, executable, argv, &CLIMapper.codex/1)
+        end
+      end
     end
   rescue
     exception ->
-      {:error,
-       Error.validation("invalid Codex options", provider: :codex, details: %{message: Exception.message(exception)})}
+      if request.structured_output do
+        structured_error(:structured_execution_setup_failed)
+      else
+        {:error,
+         Error.validation("invalid Codex options", provider: :codex, details: %{message: Exception.message(exception)})}
+      end
   end
 
   @impl true
-  def status(config),
-    do:
-      Helpers.status(:codex, spec().executable, ["OPENAI_API_KEY", "CODEX_API_KEY"], config,
-        cli_path_env: "CODEX_PATH",
-        capabilities: spec().capabilities
-      )
+  def status(config) do
+    with {:ok, status} <-
+           Helpers.status(:codex, spec().executable, [], config,
+             cli_path_env: "CODEX_PATH",
+             capabilities: spec().capabilities,
+             probe_env: CodexEnvironment.cached_subscription(),
+             probe_env_mode: :replace
+           ) do
+      status =
+        if status.installed and status.compatible do
+          with :ok <- CodexCompatibility.validate(status.executable, %{}),
+               true <- CodexCompatibility.subscription_authenticated?(status.executable) do
+            %{status | authenticated: true}
+          else
+            false -> %{status | authenticated: false, error: :cached_subscription_authentication_missing}
+            {:error, error} -> %{status | compatible: false, authenticated: :unknown, error: error}
+          end
+        else
+          status
+        end
+
+      {:ok, Jido.Harness.ProviderStatus.finalize(status)}
+    end
+  end
 
   @impl true
   def install(_config, options), do: Helpers.install_npm(:codex, "@openai/codex", options)
@@ -81,9 +110,10 @@ defmodule Jido.Harness.Adapters.Codex do
   def cancel(run_id, _context), do: Helpers.cancel_cli_run(run_id)
 
   @doc false
-  def build_argv(request, options) do
+  def build_argv(request, options, schema_path \\ nil) do
     common =
       ["exec", "--json"] ++
+        structured_args(request, schema_path) ++
         CLIArgs.pair("--model", request.model) ++
         sandbox_args(request.sandbox_mode) ++
         CLIArgs.repeat("--add-dir", request.add_dirs) ++
@@ -120,6 +150,99 @@ defmodule Jido.Harness.Adapters.Codex do
       true -> :ok
     end
   end
+
+  defp run_structured(request, context, executable, options) do
+    with :ok <- validate_structured_options(request, options),
+         :ok <- CodexCompatibility.validate(executable, context),
+         {:ok, workspace} <- SchemaWorkspace.open(request.structured_output),
+         {:ok, guard} <- start_guard(workspace) do
+      prepared = isolate(request, workspace.working_directory)
+      {:ok, argv} = build_argv(prepared, options, workspace.schema_path)
+
+      case CLIStream.run(:codex, prepared, context, executable, argv, &CLIMapper.codex/1) do
+        {:ok, stream} -> {:ok, Stream.wrap(stream, request.structured_output, guard)}
+        _error -> close_guard(guard, :provider_start_failed)
+      end
+    end
+  end
+
+  defp start_guard(workspace) do
+    case WorkspaceGuard.start(workspace, self()) do
+      {:ok, guard} ->
+        {:ok, guard}
+
+      {:error, _reason} ->
+        _ = SchemaWorkspace.close(workspace)
+        structured_error(:schema_guard_failed)
+    end
+  end
+
+  defp close_guard(guard, failure_kind) do
+    :ok = WorkspaceGuard.close(guard)
+    structured_error(failure_kind)
+  end
+
+  defp validate_structured_options(request, options) do
+    cond do
+      request.provider_session_id -> unsupported_structured(:provider_session_id)
+      options[:resume_last] -> unsupported_structured(:resume_last)
+      request.add_dirs not in [nil, []] -> unsupported_structured(:add_dirs)
+      request.attachments != [] -> unsupported_structured(:attachments)
+      request.env != %{} -> unsupported_structured(:env)
+      request.sandbox_mode not in [:default, :read_only] -> unsupported_structured(:sandbox_mode)
+      request.approval_mode not in [:default, :auto_approve] -> unsupported_structured(:approval_mode)
+      Enum.any?(Map.keys(options), &(&1 != :cli_path)) -> unsupported_structured(:provider_options)
+      true -> :ok
+    end
+  end
+
+  defp isolate(request, working_directory) do
+    %{
+      request
+      | cwd: working_directory,
+        env: CodexEnvironment.cached_subscription(),
+        env_mode: :replace,
+        provider_session_id: nil,
+        add_dirs: nil,
+        attachments: [],
+        approval_mode: :auto_approve,
+        sandbox_mode: :read_only
+    }
+  end
+
+  defp structured_args(%{structured_output: nil}, _schema_path), do: []
+
+  defp structured_args(%{structured_output: %{}}, schema_path) when is_binary(schema_path) do
+    [
+      "--ephemeral",
+      "--ignore-user-config",
+      "--ignore-rules",
+      "--output-schema",
+      schema_path,
+      "--skip-git-repo-check"
+    ] ++
+      CLIArgs.config("project_doc_max_bytes", 0) ++
+      ["--config", "project_doc_fallback_filenames=[]"] ++
+      CLIArgs.config("shell_environment_policy.inherit", "none") ++
+      CLIArgs.config("features.web_search_request", false) ++
+      CLIArgs.config("sandbox_workspace_write.network_access", false)
+  end
+
+  defp unsupported_structured(field),
+    do:
+      {:error,
+       Error.validation("option is incompatible with isolated structured output",
+         provider: :codex,
+         details: %{field: field, failure_kind: :incompatible_option}
+       )}
+
+  defp structured_error(kind),
+    do:
+      {:error,
+       Error.execution("structured-output execution could not start",
+         provider: :codex,
+         details: %{failure_kind: kind}
+       )}
 
   defp approval_args(:default), do: []
   defp approval_args(:prompt), do: CLIArgs.config("approval_policy", "on-request")

--- a/lib/jido_harness/adapters/codex.ex
+++ b/lib/jido_harness/adapters/codex.ex
@@ -29,7 +29,8 @@ defmodule Jido.Harness.Adapters.Codex do
         resume?: true,
         usage?: true,
         file_changes?: true,
-        native_cancel?: true
+        native_cancel?: true,
+        structured_output?: true
       },
       default_session_transport: :exec_jsonl_resume,
       session_transports: [Jido.Harness.SessionTransportSpec.managed(:exec_jsonl_resume, %{multimodal: :managed})],
@@ -41,7 +42,8 @@ defmodule Jido.Harness.Adapters.Codex do
         :approval_mode,
         :sandbox_mode,
         :attachments,
-        :reasoning_effort
+        :reasoning_effort,
+        :structured_output
       ],
       provider_options: @provider_options,
       install: %{npm: "@openai/codex"}

--- a/lib/jido_harness/adapters/codex_compatibility.ex
+++ b/lib/jido_harness/adapters/codex_compatibility.ex
@@ -1,0 +1,89 @@
+defmodule Jido.Harness.Adapters.CodexCompatibility do
+  @moduledoc false
+
+  alias Jido.Harness.{Error, ProcessEvent, ProcessInfo, ProcessManager}
+  alias Jido.Harness.Adapters.CodexEnvironment
+
+  @minimum_version Version.parse!("0.144.6")
+  @required_exec_flags ~w(--output-schema --ephemeral --ignore-user-config --ignore-rules)
+
+  @doc false
+  @spec validate(String.t(), map()) :: :ok | {:error, Error.t()}
+  def validate(executable, context) do
+    manager = Map.get(context, :process_manager, ProcessManager)
+
+    with {:ok, version_output} <- probe(manager, executable, ["--version"]),
+         {:ok, version} <- parse_version(version_output),
+         :ok <- minimum_version(version),
+         {:ok, help_output} <- probe(manager, executable, ["exec", "--help"]),
+         :ok <- required_flags(help_output) do
+      :ok
+    else
+      {:error, %Error{} = error} -> {:error, error}
+      _error -> incompatible()
+    end
+  end
+
+  @doc false
+  @spec subscription_authenticated?(String.t(), map()) :: boolean()
+  def subscription_authenticated?(executable, context \\ %{}) do
+    manager = Map.get(context, :process_manager, ProcessManager)
+    match?({:ok, _output}, probe(manager, executable, ["login", "status"]))
+  end
+
+  defp probe(manager, executable, argv) do
+    spec = %{
+      executable: executable,
+      argv: argv,
+      stdin: false,
+      env: CodexEnvironment.cached_subscription(),
+      env_mode: :replace,
+      runtime_timeout_ms: 15_000,
+      idle_timeout_ms: 15_000,
+      metadata: %{provider: :codex, operation: :compatibility_probe}
+    }
+
+    case manager.start_owned_process(spec, self()) do
+      {:ok, id} ->
+        try do
+          with {:ok, %ProcessInfo{state: :exited}} <- manager.await_process(id, 20_000),
+               {:ok, events} <- manager.replay_process(id, cursor: 0, limit: 1_000) do
+            {:ok,
+             events
+             |> Enum.filter(&match?(%ProcessEvent{type: type} when type in [:stdout, :stderr], &1))
+             |> Enum.map_join("", &to_string(&1.data))}
+          else
+            _error -> incompatible()
+          end
+        after
+          _ = manager.prune_process(id)
+        end
+
+      _error ->
+        incompatible()
+    end
+  end
+
+  defp parse_version(output) do
+    case Regex.run(~r/\b(\d+\.\d+\.\d+)\b/, output, capture: :all_but_first) do
+      [version] -> Version.parse(version)
+      _match -> incompatible()
+    end
+  end
+
+  defp minimum_version(version) do
+    if Version.compare(version, @minimum_version) in [:eq, :gt], do: :ok, else: incompatible()
+  end
+
+  defp required_flags(output) do
+    if Enum.all?(@required_exec_flags, &String.contains?(output, &1)), do: :ok, else: incompatible()
+  end
+
+  defp incompatible,
+    do:
+      {:error,
+       Error.new(:configuration, "Codex CLI is incompatible with structured output",
+         provider: :codex,
+         details: %{failure_kind: :incompatible_cli, minimum_version: to_string(@minimum_version)}
+       )}
+end

--- a/lib/jido_harness/adapters/codex_environment.ex
+++ b/lib/jido_harness/adapters/codex_environment.ex
@@ -1,0 +1,19 @@
+defmodule Jido.Harness.Adapters.CodexEnvironment do
+  @moduledoc false
+
+  @cached_subscription_variables ~w(
+    HOME CODEX_HOME PATH TMPDIR TEMP TMP SSL_CERT_FILE SSL_CERT_DIR
+    NIX_SSL_CERT_FILE LANG LC_ALL
+  )
+
+  @doc false
+  @spec cached_subscription() :: %{optional(String.t()) => String.t()}
+  def cached_subscription do
+    Enum.reduce(@cached_subscription_variables, %{}, fn name, env ->
+      case System.get_env(name) do
+        value when is_binary(value) and value != "" -> Map.put(env, name, value)
+        _missing -> env
+      end
+    end)
+  end
+end

--- a/lib/jido_harness/adapters/helpers.ex
+++ b/lib/jido_harness/adapters/helpers.ex
@@ -59,7 +59,7 @@ defmodule Jido.Harness.Adapters.Helpers do
     status =
       case Jido.Harness.ProcessSpec.resolve_executable(executable) do
         {:ok, path} ->
-          with {:ok, output} <- probe(path, version_argv),
+          with {:ok, output} <- probe(path, version_argv, options),
                :ok <- compatibility_probe(path, options) do
             %ProviderStatus{
               provider: provider,
@@ -132,8 +132,16 @@ defmodule Jido.Harness.Adapters.Helpers do
     :ok
   end
 
-  defp probe(path, argv) do
-    with {:ok, id} <- ProcessManager.start_process(%{executable: path, argv: argv, runtime_timeout_ms: 15_000}),
+  defp probe(path, argv, options) do
+    spec = %{
+      executable: path,
+      argv: argv,
+      runtime_timeout_ms: 15_000,
+      env: Keyword.get(options, :probe_env, %{}),
+      env_mode: Keyword.get(options, :probe_env_mode, :overlay)
+    }
+
+    with {:ok, id} <- ProcessManager.start_process(spec),
          {:ok, info} <- ProcessManager.await_process(id, 20_000),
          {:ok, events} <- ProcessManager.replay_process(id, cursor: 0, limit: 1_000) do
       output = events |> Enum.filter(&(&1.type in [:stdout, :stderr])) |> Enum.map_join("", &to_string(&1.data))
@@ -145,7 +153,7 @@ defmodule Jido.Harness.Adapters.Helpers do
   defp compatibility_probe(path, options) do
     with argv when is_list(argv) <- Keyword.get(options, :compatibility_argv),
          pattern when is_binary(pattern) <- Keyword.get(options, :compatibility_pattern),
-         {:ok, output} <- probe(path, argv) do
+         {:ok, output} <- probe(path, argv, options) do
       if String.contains?(output, pattern), do: :ok, else: {:error, {:incompatible_cli, pattern}}
     else
       nil -> :ok

--- a/lib/jido_harness/capabilities.ex
+++ b/lib/jido_harness/capabilities.ex
@@ -11,7 +11,8 @@ defmodule Jido.Harness.Capabilities do
               resume?: Zoi.boolean() |> Zoi.default(false),
               usage?: Zoi.boolean() |> Zoi.default(false),
               file_changes?: Zoi.boolean() |> Zoi.default(false),
-              native_cancel?: Zoi.boolean() |> Zoi.default(false)
+              native_cancel?: Zoi.boolean() |> Zoi.default(false),
+              structured_output?: Zoi.boolean() |> Zoi.default(false)
             },
             coerce: true
           )

--- a/lib/jido_harness/event.ex
+++ b/lib/jido_harness/event.ex
@@ -28,6 +28,7 @@ defmodule Jido.Harness.Event do
     :turn_started,
     :output_text_delta,
     :output_text_final,
+    :structured_output,
     :thinking_delta,
     :command_output_delta,
     :tool_call,

--- a/lib/jido_harness/json_schema.ex
+++ b/lib/jido_harness/json_schema.ex
@@ -1,0 +1,230 @@
+defmodule Jido.Harness.JSONSchema do
+  @moduledoc false
+
+  alias Jido.Harness.Error
+
+  @maximum_bytes 65_536
+  @maximum_depth 16
+  @maximum_properties 256
+  @maximum_enum_values 128
+  @maximum_combinators 32
+  @types ~w(null boolean object array number integer string)
+  @keywords MapSet.new(~w(
+    $schema title description type properties required additionalProperties
+    items enum const minLength maxLength minimum maximum minItems maxItems
+    anyOf oneOf allOf
+  ))
+
+  @spec admit(map()) :: :ok | {:error, Error.t()}
+  def admit(schema) when is_map(schema) do
+    with {:ok, encoded} <- encode(schema),
+         :ok <- within(byte_size(encoded), @maximum_bytes, :schema_too_large),
+         {:ok, _counts} <- validate_schema(schema, 1, %{properties: 0, enums: 0, combinators: 0}) do
+      :ok
+    end
+  end
+
+  def admit(_schema), do: invalid(:schema_not_object)
+
+  @spec encode(map()) :: {:ok, binary()} | {:error, Error.t()}
+  def encode(schema) when is_map(schema) do
+    case Jason.encode(canonical(schema)) do
+      {:ok, encoded} -> {:ok, encoded}
+      {:error, _reason} -> invalid(:schema_not_json)
+    end
+  rescue
+    _exception -> invalid(:schema_not_json)
+  end
+
+  defp validate_schema(schema, depth, counts) when depth <= @maximum_depth do
+    with :ok <- string_keys(schema),
+         :ok <- supported_keywords(schema),
+         :ok <- validate_type(schema),
+         :ok <- validate_required(schema),
+         :ok <- validate_scalar_limits(schema),
+         {:ok, counts} <- validate_properties(schema, depth, counts),
+         {:ok, counts} <- validate_items(schema, depth, counts),
+         {:ok, counts} <- validate_additional_properties(schema, depth, counts),
+         {:ok, counts} <- validate_enum(schema, counts),
+         {:ok, counts} <- validate_combinators(schema, depth, counts) do
+      {:ok, counts}
+    end
+  end
+
+  defp validate_schema(_schema, _depth, _counts), do: invalid(:schema_too_deep)
+
+  defp string_keys(schema) do
+    if Enum.all?(Map.keys(schema), &is_binary/1), do: :ok, else: invalid(:non_string_schema_key)
+  end
+
+  defp supported_keywords(schema) do
+    case Enum.find(Map.keys(schema), &(not MapSet.member?(@keywords, &1))) do
+      nil -> :ok
+      _keyword -> invalid(:unsupported_schema_keyword)
+    end
+  end
+
+  defp validate_type(%{"type" => type}) when type in @types, do: :ok
+
+  defp validate_type(%{"type" => types}) when is_list(types) do
+    if types != [] and Enum.all?(types, &(&1 in @types)) and length(types) == length(Enum.uniq(types)),
+      do: :ok,
+      else: invalid(:invalid_schema_type)
+  end
+
+  defp validate_type(schema), do: if(Map.has_key?(schema, "type"), do: invalid(:invalid_schema_type), else: :ok)
+
+  defp validate_required(%{"required" => required, "properties" => properties})
+       when is_list(required) and is_map(properties) do
+    property_names = Map.keys(properties)
+
+    if Enum.all?(required, &is_binary/1) and length(required) == length(Enum.uniq(required)) and
+         Enum.all?(required, &(&1 in property_names)) do
+      :ok
+    else
+      invalid(:invalid_required_properties)
+    end
+  end
+
+  defp validate_required(%{"required" => _required}), do: invalid(:invalid_required_properties)
+  defp validate_required(_schema), do: :ok
+
+  defp validate_scalar_limits(schema) do
+    checks = [
+      {"minLength", &non_negative_integer?/1},
+      {"maxLength", &non_negative_integer?/1},
+      {"minimum", &is_number/1},
+      {"maximum", &is_number/1},
+      {"minItems", &non_negative_integer?/1},
+      {"maxItems", &non_negative_integer?/1}
+    ]
+
+    if Enum.all?(checks, fn {key, valid?} -> not Map.has_key?(schema, key) or valid?.(schema[key]) end),
+      do: validate_limit_order(schema),
+      else: invalid(:invalid_schema_limit)
+  end
+
+  defp validate_limit_order(schema) do
+    pairs = [{"minLength", "maxLength"}, {"minimum", "maximum"}, {"minItems", "maxItems"}]
+
+    if Enum.all?(pairs, fn {minimum, maximum} ->
+         not (Map.has_key?(schema, minimum) and Map.has_key?(schema, maximum)) or schema[minimum] <= schema[maximum]
+       end),
+       do: :ok,
+       else: invalid(:invalid_schema_limit)
+  end
+
+  defp validate_properties(%{"properties" => properties}, depth, counts) when is_map(properties) do
+    count = counts.properties + map_size(properties)
+
+    with :ok <- within(count, @maximum_properties, :too_many_schema_properties) do
+      Enum.reduce_while(properties, {:ok, %{counts | properties: count}}, fn
+        {name, child}, {:ok, acc} when is_binary(name) and is_map(child) ->
+          case validate_schema(child, depth + 1, acc) do
+            {:ok, next} -> {:cont, {:ok, next}}
+            error -> {:halt, error}
+          end
+
+        _entry, _acc ->
+          {:halt, invalid(:invalid_schema_properties)}
+      end)
+    end
+  end
+
+  defp validate_properties(%{"properties" => _properties}, _depth, _counts),
+    do: invalid(:invalid_schema_properties)
+
+  defp validate_properties(_schema, _depth, counts), do: {:ok, counts}
+
+  defp validate_items(%{"items" => child}, depth, counts) when is_map(child),
+    do: validate_schema(child, depth + 1, counts)
+
+  defp validate_items(%{"items" => _child}, _depth, _counts), do: invalid(:invalid_schema_items)
+  defp validate_items(_schema, _depth, counts), do: {:ok, counts}
+
+  defp validate_additional_properties(%{"additionalProperties" => value}, _depth, counts)
+       when is_boolean(value),
+       do: {:ok, counts}
+
+  defp validate_additional_properties(%{"additionalProperties" => child}, depth, counts) when is_map(child),
+    do: validate_schema(child, depth + 1, counts)
+
+  defp validate_additional_properties(%{"additionalProperties" => _value}, _depth, _counts),
+    do: invalid(:invalid_additional_properties)
+
+  defp validate_additional_properties(_schema, _depth, counts), do: {:ok, counts}
+
+  defp validate_enum(%{"enum" => values}, counts) when is_list(values) and values != [] do
+    count = counts.enums + length(values)
+
+    with :ok <- within(count, @maximum_enum_values, :too_many_schema_enum_values),
+         {:ok, _encoded} <- Jason.encode(values) do
+      {:ok, %{counts | enums: count}}
+    else
+      {:error, %Error{} = error} -> {:error, error}
+      {:error, _reason} -> invalid(:invalid_schema_enum)
+    end
+  end
+
+  defp validate_enum(%{"enum" => _values}, _counts), do: invalid(:invalid_schema_enum)
+  defp validate_enum(_schema, counts), do: {:ok, counts}
+
+  defp validate_combinators(schema, depth, counts) do
+    Enum.reduce_while(~w(anyOf oneOf allOf), {:ok, counts}, fn keyword, {:ok, acc} ->
+      case Map.fetch(schema, keyword) do
+        :error ->
+          {:cont, {:ok, acc}}
+
+        {:ok, branches} when is_list(branches) and branches != [] ->
+          count = acc.combinators + length(branches)
+
+          case within(count, @maximum_combinators, :too_many_schema_combinators) do
+            :ok ->
+              result =
+                Enum.reduce_while(branches, {:ok, %{acc | combinators: count}}, fn
+                  branch, {:ok, branch_counts} when is_map(branch) ->
+                    case validate_schema(branch, depth + 1, branch_counts) do
+                      {:ok, next} -> {:cont, {:ok, next}}
+                      error -> {:halt, error}
+                    end
+
+                  _branch, _state ->
+                    {:halt, invalid(:invalid_schema_combinator)}
+                end)
+
+              case result do
+                {:ok, next} -> {:cont, {:ok, next}}
+                error -> {:halt, error}
+              end
+
+            error ->
+              {:halt, error}
+          end
+
+        {:ok, _branches} ->
+          {:halt, invalid(:invalid_schema_combinator)}
+      end
+    end)
+  end
+
+  defp canonical(map) when is_map(map) do
+    map
+    |> Enum.sort_by(fn {key, _value} -> key end)
+    |> Enum.map(fn {key, value} -> {key, canonical(value)} end)
+    |> Jason.OrderedObject.new()
+  end
+
+  defp canonical(list) when is_list(list), do: Enum.map(list, &canonical/1)
+  defp canonical(value), do: value
+
+  defp non_negative_integer?(value), do: is_integer(value) and value >= 0
+  defp within(value, maximum, _kind) when value <= maximum, do: :ok
+  defp within(_value, _maximum, kind), do: invalid(kind)
+
+  defp invalid(kind),
+    do:
+      {:error,
+       Error.validation("structured-output schema is not supported",
+         details: %{failure_kind: kind, field: :structured_output}
+       )}
+end

--- a/lib/jido_harness/json_schema.ex
+++ b/lib/jido_harness/json_schema.ex
@@ -15,6 +15,7 @@ defmodule Jido.Harness.JSONSchema do
     anyOf oneOf allOf
   ))
 
+  @doc false
   @spec admit(map()) :: :ok | {:error, Error.t()}
   def admit(schema) when is_map(schema) do
     with {:ok, encoded} <- encode(schema),
@@ -26,6 +27,7 @@ defmodule Jido.Harness.JSONSchema do
 
   def admit(_schema), do: invalid(:schema_not_object)
 
+  @doc false
   @spec encode(map()) :: {:ok, binary()} | {:error, Error.t()}
   def encode(schema) when is_map(schema) do
     case Jason.encode(canonical(schema)) do
@@ -34,6 +36,15 @@ defmodule Jido.Harness.JSONSchema do
     end
   rescue
     _exception -> invalid(:schema_not_json)
+  end
+
+  @doc false
+  @spec validate(term(), map()) :: :ok | {:error, Error.t()}
+  def validate(value, schema) when is_map(schema) do
+    case validate_value(value, schema) do
+      :ok -> :ok
+      :error -> invalid(:schema_validation_failed)
+    end
   end
 
   defp validate_schema(schema, depth, counts) when depth <= @maximum_depth do
@@ -216,6 +227,115 @@ defmodule Jido.Harness.JSONSchema do
 
   defp canonical(list) when is_list(list), do: Enum.map(list, &canonical/1)
   defp canonical(value), do: value
+
+  defp validate_value(value, schema) do
+    with :ok <- validate_value_type(value, schema["type"]),
+         :ok <- validate_value_enum(value, schema),
+         :ok <- validate_value_const(value, schema),
+         :ok <- validate_string(value, schema),
+         :ok <- validate_number(value, schema),
+         :ok <- validate_array(value, schema),
+         :ok <- validate_object(value, schema),
+         :ok <- validate_value_combinators(value, schema) do
+      :ok
+    end
+  end
+
+  defp validate_value_type(_value, nil), do: :ok
+
+  defp validate_value_type(value, types) when is_list(types),
+    do: if(Enum.any?(types, &type?(&1, value)), do: :ok, else: :error)
+
+  defp validate_value_type(value, type), do: if(type?(type, value), do: :ok, else: :error)
+
+  defp type?("null", value), do: is_nil(value)
+  defp type?("boolean", value), do: is_boolean(value)
+  defp type?("object", value), do: is_map(value)
+  defp type?("array", value), do: is_list(value)
+  defp type?("number", value), do: is_number(value)
+  defp type?("integer", value), do: is_integer(value)
+  defp type?("string", value), do: is_binary(value)
+  defp type?(_type, _value), do: false
+
+  defp validate_value_enum(value, %{"enum" => values}), do: if(value in values, do: :ok, else: :error)
+  defp validate_value_enum(_value, _schema), do: :ok
+  defp validate_value_const(value, %{"const" => expected}), do: if(value == expected, do: :ok, else: :error)
+  defp validate_value_const(_value, _schema), do: :ok
+
+  defp validate_string(value, schema) when is_binary(value) do
+    length = String.length(value)
+
+    if (not Map.has_key?(schema, "minLength") or length >= schema["minLength"]) and
+         (not Map.has_key?(schema, "maxLength") or length <= schema["maxLength"]),
+       do: :ok,
+       else: :error
+  end
+
+  defp validate_string(_value, _schema), do: :ok
+
+  defp validate_number(value, schema) when is_number(value) do
+    if (not Map.has_key?(schema, "minimum") or value >= schema["minimum"]) and
+         (not Map.has_key?(schema, "maximum") or value <= schema["maximum"]),
+       do: :ok,
+       else: :error
+  end
+
+  defp validate_number(_value, _schema), do: :ok
+
+  defp validate_array(value, schema) when is_list(value) do
+    valid_length =
+      (not Map.has_key?(schema, "minItems") or length(value) >= schema["minItems"]) and
+        (not Map.has_key?(schema, "maxItems") or length(value) <= schema["maxItems"])
+
+    valid_items =
+      case schema["items"] do
+        nil -> true
+        item_schema -> Enum.all?(value, &(validate_value(&1, item_schema) == :ok))
+      end
+
+    if valid_length and valid_items, do: :ok, else: :error
+  end
+
+  defp validate_array(_value, _schema), do: :ok
+
+  defp validate_object(value, schema) when is_map(value) do
+    properties = Map.get(schema, "properties", %{})
+    required = Map.get(schema, "required", [])
+    additional = Map.get(schema, "additionalProperties", true)
+
+    required? = Enum.all?(required, &Map.has_key?(value, &1))
+
+    properties? =
+      Enum.all?(value, fn {key, child} ->
+        case Map.fetch(properties, key) do
+          {:ok, child_schema} -> validate_value(child, child_schema) == :ok
+          :error when additional == true -> true
+          :error when additional == false -> false
+          :error when is_map(additional) -> validate_value(child, additional) == :ok
+        end
+      end)
+
+    if required? and properties?, do: :ok, else: :error
+  end
+
+  defp validate_object(_value, _schema), do: :ok
+
+  defp validate_value_combinators(value, schema) do
+    checks = [
+      {"allOf", fn matches -> matches == length(schema["allOf"]) end},
+      {"anyOf", fn matches -> matches >= 1 end},
+      {"oneOf", fn matches -> matches == 1 end}
+    ]
+
+    if Enum.all?(checks, fn {keyword, accepted?} ->
+         case schema[keyword] do
+           nil -> true
+           branches -> branches |> Enum.count(&(validate_value(value, &1) == :ok)) |> accepted?.()
+         end
+       end),
+       do: :ok,
+       else: :error
+  end
 
   defp non_negative_integer?(value), do: is_integer(value) and value >= 0
   defp within(value, maximum, _kind) when value <= maximum, do: :ok

--- a/lib/jido_harness/json_schema.ex
+++ b/lib/jido_harness/json_schema.ex
@@ -6,13 +6,11 @@ defmodule Jido.Harness.JSONSchema do
   @maximum_bytes 65_536
   @maximum_depth 16
   @maximum_properties 256
-  @maximum_enum_values 128
-  @maximum_combinators 32
+  @maximum_enum_values 256
   @types ~w(null boolean object array number integer string)
   @keywords MapSet.new(~w(
     $schema title description type properties required additionalProperties
     items enum const minLength maxLength minimum maximum minItems maxItems
-    anyOf oneOf allOf
   ))
 
   @doc false
@@ -20,7 +18,7 @@ defmodule Jido.Harness.JSONSchema do
   def admit(schema) when is_map(schema) do
     with {:ok, encoded} <- encode(schema),
          :ok <- within(byte_size(encoded), @maximum_bytes, :schema_too_large),
-         {:ok, _counts} <- validate_schema(schema, 1, %{properties: 0, enums: 0, combinators: 0}) do
+         {:ok, _counts} <- validate_schema(schema, 1, %{properties: 0, enums: 0}) do
       :ok
     end
   end
@@ -56,8 +54,7 @@ defmodule Jido.Harness.JSONSchema do
          {:ok, counts} <- validate_properties(schema, depth, counts),
          {:ok, counts} <- validate_items(schema, depth, counts),
          {:ok, counts} <- validate_additional_properties(schema, depth, counts),
-         {:ok, counts} <- validate_enum(schema, counts),
-         {:ok, counts} <- validate_combinators(schema, depth, counts) do
+         {:ok, counts} <- validate_enum(schema, counts) do
       {:ok, counts}
     end
   end
@@ -180,44 +177,6 @@ defmodule Jido.Harness.JSONSchema do
   defp validate_enum(%{"enum" => _values}, _counts), do: invalid(:invalid_schema_enum)
   defp validate_enum(_schema, counts), do: {:ok, counts}
 
-  defp validate_combinators(schema, depth, counts) do
-    Enum.reduce_while(~w(anyOf oneOf allOf), {:ok, counts}, fn keyword, {:ok, acc} ->
-      case Map.fetch(schema, keyword) do
-        :error ->
-          {:cont, {:ok, acc}}
-
-        {:ok, branches} when is_list(branches) and branches != [] ->
-          count = acc.combinators + length(branches)
-
-          case within(count, @maximum_combinators, :too_many_schema_combinators) do
-            :ok ->
-              result =
-                Enum.reduce_while(branches, {:ok, %{acc | combinators: count}}, fn
-                  branch, {:ok, branch_counts} when is_map(branch) ->
-                    case validate_schema(branch, depth + 1, branch_counts) do
-                      {:ok, next} -> {:cont, {:ok, next}}
-                      error -> {:halt, error}
-                    end
-
-                  _branch, _state ->
-                    {:halt, invalid(:invalid_schema_combinator)}
-                end)
-
-              case result do
-                {:ok, next} -> {:cont, {:ok, next}}
-                error -> {:halt, error}
-              end
-
-            error ->
-              {:halt, error}
-          end
-
-        {:ok, _branches} ->
-          {:halt, invalid(:invalid_schema_combinator)}
-      end
-    end)
-  end
-
   defp canonical(map) when is_map(map) do
     map
     |> Enum.sort_by(fn {key, _value} -> key end)
@@ -235,8 +194,7 @@ defmodule Jido.Harness.JSONSchema do
          :ok <- validate_string(value, schema),
          :ok <- validate_number(value, schema),
          :ok <- validate_array(value, schema),
-         :ok <- validate_object(value, schema),
-         :ok <- validate_value_combinators(value, schema) do
+         :ok <- validate_object(value, schema) do
       :ok
     end
   end
@@ -319,23 +277,6 @@ defmodule Jido.Harness.JSONSchema do
   end
 
   defp validate_object(_value, _schema), do: :ok
-
-  defp validate_value_combinators(value, schema) do
-    checks = [
-      {"allOf", fn matches -> matches == length(schema["allOf"]) end},
-      {"anyOf", fn matches -> matches >= 1 end},
-      {"oneOf", fn matches -> matches == 1 end}
-    ]
-
-    if Enum.all?(checks, fn {keyword, accepted?} ->
-         case schema[keyword] do
-           nil -> true
-           branches -> branches |> Enum.count(&(validate_value(value, &1) == :ok)) |> accepted?.()
-         end
-       end),
-       do: :ok,
-       else: :error
-  end
 
   defp non_negative_integer?(value), do: is_integer(value) and value >= 0
   defp within(value, maximum, _kind) when value <= maximum, do: :ok

--- a/lib/jido_harness/run/request.ex
+++ b/lib/jido_harness/run/request.ex
@@ -25,6 +25,7 @@ defmodule Jido.Harness.RunRequest do
     :env,
     :env_mode,
     :metadata,
+    :structured_output,
     :provider_options
   ]
 
@@ -51,6 +52,7 @@ defmodule Jido.Harness.RunRequest do
               env: Zoi.map(Zoi.string(), Zoi.any()) |> Zoi.default(%{}),
               env_mode: Zoi.enum([:overlay, :replace]) |> Zoi.default(:overlay),
               metadata: Zoi.map(Zoi.union([Zoi.string(), Zoi.atom()]), Zoi.any()) |> Zoi.default(%{}),
+              structured_output: Jido.Harness.StructuredOutput.schema() |> Zoi.nullish(),
               provider_options: Zoi.map(Zoi.union([Zoi.string(), Zoi.atom()]), Zoi.any()) |> Zoi.default(%{})
             },
             coerce: true
@@ -72,6 +74,7 @@ defmodule Jido.Harness.RunRequest do
     with {:ok, normalized} <- normalize_keys(attrs),
          :ok <- validate_values(normalized),
          {:ok, request} <- parse(Map.put_new(normalized, :cwd, File.cwd!())),
+         :ok <- validate_structured_output(request.structured_output),
          :ok <- validate_cwd(request.cwd) do
       {:ok, request}
     end
@@ -167,4 +170,9 @@ defmodule Jido.Harness.RunRequest do
       {:error, Jido.Harness.Error.validation("cwd must be an existing directory", details: %{cwd: path})}
     end
   end
+
+  defp validate_structured_output(nil), do: :ok
+
+  defp validate_structured_output(%Jido.Harness.StructuredOutput{} = output),
+    do: Jido.Harness.StructuredOutput.validate(output)
 end

--- a/lib/jido_harness/run/result.ex
+++ b/lib/jido_harness/run/result.ex
@@ -19,6 +19,7 @@ defmodule Jido.Harness.RunResult do
               status: Zoi.enum([:completed, :failed, :cancelled]),
               text: Zoi.string() |> Zoi.default(""),
               text_truncated?: Zoi.boolean() |> Zoi.default(false),
+              structured_output: Zoi.map() |> Zoi.nullish(),
               usage: Zoi.map() |> Zoi.default(%{}),
               events: Zoi.array(Event.schema()) |> Zoi.default([]),
               metadata: Zoi.map() |> Zoi.default(%{}),

--- a/lib/jido_harness/run/result.ex
+++ b/lib/jido_harness/run/result.ex
@@ -4,8 +4,9 @@ defmodule Jido.Harness.RunResult do
 
   `status` is `:completed`, `:failed`, or `:cancelled`. `text` is a bounded
   output tail; when `text_truncated?` is true, cursor replay is the source for
-  the complete retained event sequence. Optional usage depends on provider
-  capability.
+  the complete retained event sequence. A successful structured run also sets
+  `structured_output` to a map containing its `schema_id` and validated
+  `value`. Optional usage depends on provider capability.
   """
 
   alias Jido.Harness.{Error, Event}

--- a/lib/jido_harness/run/worker.ex
+++ b/lib/jido_harness/run/worker.ex
@@ -50,6 +50,7 @@ defmodule Jido.Harness.RunWorker do
       terminal_event: nil,
       text_tail: TextTail.new(memory_bytes),
       final_text_tail: nil,
+      structured_output: nil,
       usage: %{},
       error: nil,
       result: nil,
@@ -278,6 +279,10 @@ defmodule Jido.Harness.RunWorker do
     end
   end
 
+  defp accumulate(state, %Event{type: :structured_output, payload: payload}) do
+    %{state | structured_output: Map.take(payload, ["schema_id", "value"])}
+  end
+
   defp accumulate(state, %Event{type: :usage, payload: payload}), do: %{state | usage: Map.merge(state.usage, payload)}
   defp accumulate(state, _event), do: state
 
@@ -307,6 +312,7 @@ defmodule Jido.Harness.RunWorker do
       status: status,
       text: text.data,
       text_truncated?: text.truncated?,
+      structured_output: state.structured_output,
       usage: state.usage,
       events: events,
       metadata: state.request.metadata,
@@ -385,9 +391,13 @@ defmodule Jido.Harness.RunWorker do
         _value -> "provider reported failure"
       end
 
-    error = state.error || Error.execution(message, provider: state.provider, run_id: state.id)
+    details = failure_details(payload)
+    error = state.error || Error.execution(message, provider: state.provider, run_id: state.id, details: details)
     finalize(state, :failed, error)
   end
+
+  defp failure_details(%{"failure_kind" => kind}) when is_binary(kind), do: %{failure_kind: kind}
+  defp failure_details(_payload), do: %{}
 
   defp schedule_runtime(%{request: %{runtime_timeout_ms: :infinity}} = state), do: state
 

--- a/lib/jido_harness/session/transports/acp.ex
+++ b/lib/jido_harness/session/transports/acp.ex
@@ -69,7 +69,7 @@ defmodule Jido.Harness.SessionAdapters.ACPTransport do
         "fs" => %{"readTextFile" => false, "writeTextFile" => false},
         "terminal" => false
       },
-      "clientInfo" => %{"name" => "jido_harness", "title" => "Jido Harness", "version" => "2.0.0"}
+      "clientInfo" => %{"name" => "jido_harness", "title" => "Jido Harness", "version" => Jido.Harness.version()}
     }
 
     with {:ok, state} <- request(state, "initialize", params, {:initialize, from, request}) do

--- a/lib/jido_harness/structured_output.ex
+++ b/lib/jido_harness/structured_output.ex
@@ -1,0 +1,83 @@
+defmodule Jido.Harness.StructuredOutput do
+  @moduledoc """
+  A bounded JSON Schema contract for one finite harness run.
+
+  Callers provide the schema as data. Harness adapters own any provider-specific
+  serialization and must never accept a caller-supplied schema path.
+  """
+
+  alias Jido.Harness.{Error, JSONSchema}
+
+  @default_max_output_bytes 262_144
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              schema_id: Zoi.string(),
+              schema: Zoi.map(),
+              max_output_bytes: Zoi.integer() |> Zoi.default(@default_max_output_bytes)
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the validation schema for structured-output contracts."
+  @spec schema() :: Zoi.schema()
+  def schema, do: @schema
+
+  @doc "Validates and constructs a bounded structured-output contract."
+  @spec new(map() | keyword()) :: {:ok, t()} | {:error, Error.t()}
+  def new(attrs) when is_map(attrs) or is_list(attrs) do
+    with {:ok, output} <- parse(attrs),
+         :ok <- validate_schema_id(output.schema_id),
+         :ok <- validate_output_limit(output.max_output_bytes),
+         :ok <- JSONSchema.admit(output.schema) do
+      {:ok, output}
+    end
+  end
+
+  def new(_attrs), do: invalid(:structured_output, "structured_output must be a map or keyword list")
+
+  @doc false
+  @spec validate(t()) :: :ok | {:error, Error.t()}
+  def validate(%__MODULE__{} = output) do
+    with :ok <- validate_schema_id(output.schema_id),
+         :ok <- validate_output_limit(output.max_output_bytes),
+         :ok <- JSONSchema.admit(output.schema) do
+      :ok
+    end
+  end
+
+  @doc "Validates and constructs a structured-output contract, raising on error."
+  @spec new!(map() | keyword()) :: t()
+  def new!(attrs) do
+    case new(attrs) do
+      {:ok, output} -> output
+      {:error, error} -> raise error
+    end
+  end
+
+  defp parse(attrs) do
+    case Zoi.parse(@schema, Map.new(attrs)) do
+      {:ok, output} -> {:ok, output}
+      {:error, _reason} -> invalid(:invalid_contract, "invalid structured_output contract")
+    end
+  end
+
+  defp validate_schema_id(id) do
+    if is_binary(id) and byte_size(id) in 1..128 and Regex.match?(~r/\A[a-zA-Z0-9][a-zA-Z0-9_.-]*\z/, id) do
+      :ok
+    else
+      invalid(:invalid_schema_id, "structured_output schema_id is invalid")
+    end
+  end
+
+  defp validate_output_limit(limit) when is_integer(limit) and limit in 1..1_048_576, do: :ok
+  defp validate_output_limit(_limit), do: invalid(:invalid_output_limit, "structured_output byte limit is invalid")
+
+  defp invalid(kind, message),
+    do: {:error, Error.validation(message, details: %{failure_kind: kind, field: :structured_output})}
+end

--- a/lib/jido_harness/structured_output.ex
+++ b/lib/jido_harness/structured_output.ex
@@ -15,6 +15,7 @@ defmodule Jido.Harness.StructuredOutput do
             %{
               schema_id: Zoi.string(),
               schema: Zoi.map(),
+              isolation: Zoi.literal(:ephemeral_read_only) |> Zoi.default(:ephemeral_read_only),
               max_output_bytes: Zoi.integer() |> Zoi.default(@default_max_output_bytes)
             },
             coerce: true

--- a/lib/jido_harness/structured_output/schema_workspace.ex
+++ b/lib/jido_harness/structured_output/schema_workspace.ex
@@ -3,25 +3,38 @@ defmodule Jido.Harness.StructuredOutput.SchemaWorkspace do
 
   alias Jido.Harness.{Error, JSONSchema, StructuredOutput}
 
-  @enforce_keys [:directory, :schema_path]
-  defstruct [:directory, :schema_path]
+  @enforce_keys [:directory, :schema_path, :working_directory]
+  defstruct [:directory, :schema_path, :working_directory]
 
-  @type t :: %__MODULE__{directory: String.t(), schema_path: String.t()}
+  @type t :: %__MODULE__{
+          directory: String.t(),
+          schema_path: String.t(),
+          working_directory: String.t()
+        }
 
+  @doc false
   @spec open(StructuredOutput.t(), keyword()) :: {:ok, t()} | {:error, Error.t()}
   def open(%StructuredOutput{} = output, options \\ []) do
     base_directory = Keyword.get(options, :base_directory, default_base_directory())
     directory = Path.join(base_directory, random_name())
     schema_path = Path.join(directory, "schema.json")
+    working_directory = Path.join(directory, "workspace")
 
     try do
       with {:ok, encoded} <- JSONSchema.encode(output.schema),
            :ok <- prepare_base(base_directory),
            :ok <- File.mkdir(directory),
            :ok <- File.chmod(directory, 0o700),
+           :ok <- File.mkdir(working_directory),
+           :ok <- File.chmod(working_directory, 0o700),
            :ok <- write_exclusive(schema_path, encoded),
            :ok <- File.chmod(schema_path, 0o600) do
-        {:ok, %__MODULE__{directory: directory, schema_path: schema_path}}
+        {:ok,
+         %__MODULE__{
+           directory: directory,
+           schema_path: schema_path,
+           working_directory: working_directory
+         }}
       else
         {:error, %Error{} = error} ->
           _ = File.rm_rf(directory)
@@ -38,14 +51,18 @@ defmodule Jido.Harness.StructuredOutput.SchemaWorkspace do
     end
   end
 
+  @doc false
   @spec close(t()) :: :ok | {:error, Error.t()}
   def close(%__MODULE__{directory: directory}) do
     case File.rm_rf(directory) do
       {:ok, _entries} -> :ok
       {:error, _reason, _path} -> workspace_error()
     end
+  rescue
+    _exception -> workspace_error()
   end
 
+  @doc false
   @spec with_open(StructuredOutput.t(), (t() -> term()), keyword()) :: term() | {:error, Error.t()}
   def with_open(%StructuredOutput{} = output, function, options \\ []) when is_function(function, 1) do
     case open(output, options) do

--- a/lib/jido_harness/structured_output/schema_workspace.ex
+++ b/lib/jido_harness/structured_output/schema_workspace.ex
@@ -1,0 +1,93 @@
+defmodule Jido.Harness.StructuredOutput.SchemaWorkspace do
+  @moduledoc false
+
+  alias Jido.Harness.{Error, JSONSchema, StructuredOutput}
+
+  @enforce_keys [:directory, :schema_path]
+  defstruct [:directory, :schema_path]
+
+  @type t :: %__MODULE__{directory: String.t(), schema_path: String.t()}
+
+  @spec open(StructuredOutput.t(), keyword()) :: {:ok, t()} | {:error, Error.t()}
+  def open(%StructuredOutput{} = output, options \\ []) do
+    base_directory = Keyword.get(options, :base_directory, default_base_directory())
+    directory = Path.join(base_directory, random_name())
+    schema_path = Path.join(directory, "schema.json")
+
+    try do
+      with {:ok, encoded} <- JSONSchema.encode(output.schema),
+           :ok <- prepare_base(base_directory),
+           :ok <- File.mkdir(directory),
+           :ok <- File.chmod(directory, 0o700),
+           :ok <- write_exclusive(schema_path, encoded),
+           :ok <- File.chmod(schema_path, 0o600) do
+        {:ok, %__MODULE__{directory: directory, schema_path: schema_path}}
+      else
+        {:error, %Error{} = error} ->
+          _ = File.rm_rf(directory)
+          {:error, error}
+
+        {:error, _reason} ->
+          _ = File.rm_rf(directory)
+          workspace_error()
+      end
+    rescue
+      _exception ->
+        _ = File.rm_rf(directory)
+        workspace_error()
+    end
+  end
+
+  @spec close(t()) :: :ok | {:error, Error.t()}
+  def close(%__MODULE__{directory: directory}) do
+    case File.rm_rf(directory) do
+      {:ok, _entries} -> :ok
+      {:error, _reason, _path} -> workspace_error()
+    end
+  end
+
+  @spec with_open(StructuredOutput.t(), (t() -> term()), keyword()) :: term() | {:error, Error.t()}
+  def with_open(%StructuredOutput{} = output, function, options \\ []) when is_function(function, 1) do
+    case open(output, options) do
+      {:ok, workspace} ->
+        try do
+          function.(workspace)
+        after
+          _ = close(workspace)
+        end
+
+      error ->
+        error
+    end
+  end
+
+  defp prepare_base(base_directory) do
+    with :ok <- File.mkdir_p(base_directory),
+         :ok <- File.chmod(base_directory, 0o700) do
+      :ok
+    end
+  end
+
+  defp write_exclusive(path, encoded) do
+    with {:ok, device} <- File.open(path, [:write, :binary, :exclusive]) do
+      try do
+        IO.binwrite(device, encoded)
+      after
+        File.close(device)
+      end
+    end
+  end
+
+  defp random_name,
+    do: "run-" <> (:crypto.strong_rand_bytes(24) |> Base.url_encode64(padding: false))
+
+  defp default_base_directory,
+    do: Path.join(System.tmp_dir!(), "jido-harness-structured-output")
+
+  defp workspace_error,
+    do:
+      {:error,
+       Error.execution("structured-output schema staging failed",
+         details: %{failure_kind: :schema_staging_failed}
+       )}
+end

--- a/lib/jido_harness/structured_output/stream.ex
+++ b/lib/jido_harness/structured_output/stream.ex
@@ -1,0 +1,99 @@
+defmodule Jido.Harness.StructuredOutput.Stream do
+  @moduledoc false
+
+  alias Jido.Harness.{Adapters.Helpers, Event, JSONSchema, StructuredOutput}
+  alias Jido.Harness.StructuredOutput.WorkspaceGuard
+
+  @end_of_stream {:jido_harness, :structured_output_end}
+
+  @doc false
+  @spec wrap(Enumerable.t(), StructuredOutput.t(), pid()) :: Enumerable.t()
+  def wrap(stream, %StructuredOutput{} = output, guard) when is_pid(guard) do
+    stream
+    |> Stream.concat([@end_of_stream])
+    |> Stream.transform(
+      fn -> %{output: nil, output_count: 0, failure: nil, terminal?: false} end,
+      &transform(&1, &2, output),
+      fn _state -> WorkspaceGuard.close(guard) end
+    )
+  end
+
+  defp transform(@end_of_stream, %{terminal?: false} = state, _output) do
+    {[failure_event(:missing_terminal_result)], %{state | terminal?: true}}
+  end
+
+  defp transform(@end_of_stream, state, _output), do: {[], state}
+
+  defp transform(%Event{type: :output_text_delta}, state, _output), do: {[], state}
+
+  defp transform(%Event{type: :output_text_final, payload: payload}, state, output) do
+    text = payload["text"]
+    count = state.output_count + 1
+
+    state =
+      cond do
+        count > 1 -> %{state | output_count: count, failure: :duplicate_terminal_output}
+        not is_binary(text) -> %{state | output_count: count, failure: :missing_terminal_output}
+        byte_size(text) > output.max_output_bytes -> %{state | output_count: count, failure: :terminal_output_too_large}
+        true -> %{state | output_count: count, output: text}
+      end
+
+    {[], state}
+  end
+
+  defp transform(%Event{type: :run_completed} = terminal, state, output) do
+    {events, state} = complete(state, terminal, output)
+    {events, %{state | terminal?: true}}
+  end
+
+  defp transform(%Event{type: :run_failed}, state, _output) do
+    {[failure_event(:provider_execution_failed)], %{state | terminal?: true}}
+  end
+
+  defp transform(%Event{type: :run_cancelled}, state, _output) do
+    event = Helpers.event(:codex, :run_cancelled, nil, %{"reason" => "cancelled"})
+    {[event], %{state | terminal?: true}}
+  end
+
+  defp transform(%Event{type: :usage} = event, state, _output),
+    do: {[%{event | provider_session_id: nil, raw: nil}], state}
+
+  defp transform(%Event{type: type} = event, state, _output) when type in [:turn_started, :turn_completed],
+    do: {[%{event | provider_session_id: nil, raw: nil}], state}
+
+  defp transform(%Event{}, state, _output), do: {[], state}
+
+  defp complete(%{failure: failure} = state, _terminal, _output) when is_atom(failure) and not is_nil(failure),
+    do: {[failure_event(failure)], state}
+
+  defp complete(%{output_count: count} = state, _terminal, _output) when count != 1,
+    do: {[failure_event(:missing_terminal_output)], state}
+
+  defp complete(state, terminal, output) do
+    with {:ok, value} <- Jason.decode(state.output),
+         :ok <- JSONSchema.validate(value, output.schema) do
+      final = Helpers.event(:codex, :output_text_final, nil, %{"text" => state.output})
+
+      structured =
+        Helpers.event(:codex, :structured_output, nil, %{
+          "schema_id" => output.schema_id,
+          "value" => value
+        })
+
+      {[final, structured, %{terminal | provider_session_id: nil, raw: nil}], state}
+    else
+      {:error, %Jido.Harness.Error{details: %{failure_kind: kind}}} ->
+        {[failure_event(kind)], state}
+
+      {:error, _decode_error} ->
+        {[failure_event(:malformed_terminal_json)], state}
+    end
+  end
+
+  defp failure_event(kind, provider_session_id \\ nil) do
+    Helpers.event(:codex, :run_failed, provider_session_id, %{
+      "error" => "structured-output validation failed",
+      "failure_kind" => Atom.to_string(kind)
+    })
+  end
+end

--- a/lib/jido_harness/structured_output/workspace_guard.ex
+++ b/lib/jido_harness/structured_output/workspace_guard.ex
@@ -1,0 +1,62 @@
+defmodule Jido.Harness.StructuredOutput.WorkspaceGuard do
+  @moduledoc false
+
+  alias Jido.Harness.StructuredOutput.SchemaWorkspace
+
+  @doc false
+  @spec start(SchemaWorkspace.t(), pid()) :: {:ok, pid()} | {:error, :guard_start_timeout}
+  def start(%SchemaWorkspace{} = workspace, owner) when is_pid(owner) do
+    caller = self()
+    reference = make_ref()
+
+    pid =
+      spawn(fn ->
+        monitor = Process.monitor(owner)
+        send(caller, {:workspace_guard_started, reference, self()})
+        loop(workspace, monitor)
+      end)
+
+    receive do
+      {:workspace_guard_started, ^reference, ^pid} -> {:ok, pid}
+    after
+      5_000 ->
+        Process.exit(pid, :kill)
+        {:error, :guard_start_timeout}
+    end
+  end
+
+  @doc false
+  @spec close(pid()) :: :ok
+  def close(pid) when is_pid(pid) do
+    reference = make_ref()
+    monitor = Process.monitor(pid)
+    send(pid, {:close, self(), reference})
+
+    receive do
+      {:workspace_guard_closed, ^reference} ->
+        Process.demonitor(monitor, [:flush])
+        :ok
+
+      {:DOWN, ^monitor, :process, ^pid, _reason} ->
+        :ok
+    after
+      5_000 ->
+        Process.exit(pid, :kill)
+        :ok
+    end
+  end
+
+  defp loop(workspace, monitor) do
+    receive do
+      {:close, caller, reference} ->
+        _ = SchemaWorkspace.close(workspace)
+        send(caller, {:workspace_guard_closed, reference})
+
+      {:DOWN, ^monitor, :process, _pid, _reason} ->
+        _ = SchemaWorkspace.close(workspace)
+
+      _message ->
+        loop(workspace, monitor)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Jido.Harness.MixProject do
   use Mix.Project
 
-  @version "2.1.0-rc.1"
+  @version "2.1.0-rc.2"
   @source_url "https://github.com/agentjido/jido_harness"
   @description "Supervised, normalized Elixir runtime for CLI AI coding agents"
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Jido.Harness.MixProject do
   use Mix.Project
 
-  @version "2.0.0"
+  @version "2.1.0-rc.1"
   @source_url "https://github.com/agentjido/jido_harness"
   @description "Supervised, normalized Elixir runtime for CLI AI coding agents"
 
@@ -50,6 +50,7 @@ defmodule Jido.Harness.MixProject do
           "docs/process_management.md",
           "docs/integration_testing.md",
           "docs/migration_v2.md",
+          "docs/structured_output_execution.md",
           "livebooks/01_one_shot_requests.livemd",
           "livebooks/02_detached_runs.livemd",
           "livebooks/03_sessions_and_processes.livemd"
@@ -87,7 +88,8 @@ defmodule Jido.Harness.MixProject do
             "docs/integration_testing.md",
             "docs/telemetry.md",
             "docs/dependency_policy.md",
-            "docs/migration_v2.md"
+            "docs/migration_v2.md",
+            "docs/structured_output_execution.md"
           ],
           Livebooks: [
             "livebooks/01_one_shot_requests.livemd",

--- a/mix.exs
+++ b/mix.exs
@@ -105,6 +105,7 @@ defmodule Jido.Harness.MixProject do
           ],
           "Requests and results": [
             Jido.Harness.RunRequest,
+            Jido.Harness.StructuredOutput,
             Jido.Harness.RunResult,
             Jido.Harness.RunInfo,
             Jido.Harness.SessionRequest,

--- a/test/jido_harness/codex_structured_output_test.exs
+++ b/test/jido_harness/codex_structured_output_test.exs
@@ -1,0 +1,322 @@
+defmodule Jido.Harness.CodexStructuredOutputTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Harness.{Error, Event, Run, RunRequest}
+  alias Jido.Harness.Adapters.Codex
+  alias Jido.Harness.StructuredOutput.{SchemaWorkspace, Stream, WorkspaceGuard}
+
+  @schema %{
+    "type" => "object",
+    "properties" => %{
+      "department" => %{"type" => "string", "enum" => ["people", "finance"]},
+      "confidence" => %{"type" => "number", "minimum" => 0, "maximum" => 1}
+    },
+    "required" => ["department", "confidence"],
+    "additionalProperties" => false
+  }
+
+  defmodule IncompatibleProcessManager do
+    alias Jido.Harness.{ProcessEvent, ProcessInfo}
+
+    def start_owned_process(%{argv: ["--version"]}, _owner), do: {:ok, "version"}
+
+    def await_process("version", _timeout),
+      do: {:ok, ProcessInfo.new!(process_id: "version", state: :exited, started_at: timestamp())}
+
+    def replay_process("version", _options) do
+      {:ok,
+       [
+         ProcessEvent.new!(
+           process_id: "version",
+           sequence: 1,
+           timestamp: timestamp(),
+           type: :stdout,
+           data: "codex-cli 0.100.0\n"
+         )
+       ]}
+    end
+
+    def prune_process("version"), do: :ok
+    defp timestamp, do: DateTime.utc_now() |> DateTime.to_iso8601()
+  end
+
+  defmodule CompatibleStartFailureManager do
+    alias Jido.Harness.{ProcessEvent, ProcessInfo}
+
+    def start_owned_process(%{argv: ["--version"]}, _owner), do: {:ok, "version"}
+    def start_owned_process(%{argv: ["exec", "--help"]}, _owner), do: {:ok, "help"}
+    def start_owned_process(%{argv: argv}, _owner) when is_list(argv), do: {:error, :provider_start_failed}
+
+    def await_process(id, _timeout) when id in ["version", "help"],
+      do: {:ok, ProcessInfo.new!(process_id: id, state: :exited, started_at: timestamp())}
+
+    def replay_process(id, _options) do
+      output =
+        if id == "version",
+          do: "codex-cli 0.144.6\n",
+          else: "--output-schema --ephemeral --ignore-user-config --ignore-rules\n"
+
+      {:ok, [ProcessEvent.new!(process_id: id, sequence: 1, timestamp: timestamp(), type: :stdout, data: output)]}
+    end
+
+    def prune_process(_id), do: :ok
+    defp timestamp, do: DateTime.utc_now() |> DateTime.to_iso8601()
+  end
+
+  setup do
+    fixture = Jido.Harness.TestHelpers.fixture_path("fake_stream_cli.exs")
+    original_config = Application.get_env(:jido_harness, :provider_config, %{})
+    original_api_key = System.get_env("OPENAI_API_KEY")
+    original_codex_key = System.get_env("CODEX_API_KEY")
+
+    Application.put_env(
+      :jido_harness,
+      :provider_config,
+      Map.put(original_config, :codex, %{cli_path: fixture, env: %{"OPENAI_API_KEY" => "configured-secret"}})
+    )
+
+    System.put_env("OPENAI_API_KEY", "ambient-secret")
+    System.put_env("CODEX_API_KEY", "ambient-codex-secret")
+
+    on_exit(fn ->
+      Application.put_env(:jido_harness, :provider_config, original_config)
+      restore_env("OPENAI_API_KEY", original_api_key)
+      restore_env("CODEX_API_KEY", original_codex_key)
+      Jido.Harness.TestHelpers.cleanup_runs()
+      Jido.Harness.TestHelpers.cleanup_processes()
+    end)
+
+    :ok
+  end
+
+  test "builds the reviewed ephemeral read-only Codex invocation" do
+    request = request()
+
+    assert {:ok, argv} = Codex.build_argv(request, %{}, "/private/schema.json")
+    assert Enum.take(argv, 2) == ["exec", "--json"]
+    assert "--ephemeral" in argv
+    assert "--ignore-user-config" in argv
+    assert "--ignore-rules" in argv
+    assert pairs(argv, "--output-schema") == ["/private/schema.json"]
+    assert pairs(argv, "--sandbox") == ["read-only"]
+    assert "approval_policy=\"never\"" in pairs(argv, "--config")
+    assert "project_doc_max_bytes=0" in pairs(argv, "--config")
+    assert "shell_environment_policy.inherit=\"none\"" in pairs(argv, "--config")
+    assert List.last(argv) == "classify"
+  end
+
+  test "returns one schema-validated result through the managed finite-run API" do
+    before = workspace_directories()
+
+    assert {:ok, result} = Jido.Harness.run(:codex, Map.from_struct(request()), await_timeout: 10_000)
+    assert result.status == :completed
+    assert Jason.decode!(result.text) == %{"department" => "people", "confidence" => 0.9}
+
+    assert result.structured_output == %{
+             "schema_id" => "hr.classification.v1",
+             "value" => %{"department" => "people", "confidence" => 0.9}
+           }
+
+    assert result.provider_session_id == nil
+    assert Enum.count(result.events, &Event.run_terminal?/1) == 1
+    assert Enum.any?(result.events, &(&1.type == :structured_output))
+    assert workspace_directories() == before
+  end
+
+  test "rejects sessions, ambient inputs, writable modes, and provider behavior switches before execution" do
+    base = Map.from_struct(request())
+
+    for attrs <- [
+          Map.put(base, :provider_session_id, "retained"),
+          Map.put(base, :add_dirs, ["/tmp"]),
+          Map.put(base, :attachments, ["private.png"]),
+          Map.put(base, :env, %{"OPENAI_API_KEY" => "direct-secret"}),
+          Map.put(base, :sandbox_mode, :workspace_write),
+          Map.put(base, :approval_mode, :prompt),
+          Map.put(base, :provider_options, %{resume_last: true})
+        ] do
+      assert {:ok, run_id} = Run.start(:codex, attrs)
+      assert {:ok, result} = Run.await(run_id, 5_000)
+      assert result.status == :failed
+      assert %Error{category: :validation, details: %{failure_kind: :incompatible_option}} = result.error
+    end
+  end
+
+  test "normalizes missing, duplicate, malformed, oversized, and schema-invalid output" do
+    output = request().structured_output
+
+    failures = [
+      {[], "missing_terminal_output"},
+      {[final(~s({"department":"people","confidence":0.9})), final(~s({"department":"people","confidence":0.9}))],
+       "duplicate_terminal_output"},
+      {[final("not-json")], "malformed_terminal_json"},
+      {[final(~s({"department":"legal","confidence":0.9}))], "schema_validation_failed"},
+      {[final(String.duplicate("x", output.max_output_bytes + 1))], "terminal_output_too_large"}
+    ]
+
+    Enum.each(failures, fn {prefix, expected_kind} ->
+      events = enumerate(prefix ++ [completed()], output)
+      assert [%Event{type: :run_failed, payload: %{"failure_kind" => ^expected_kind}}] = events
+    end)
+  end
+
+  test "workspace guard cleans when its owner terminates" do
+    output = request().structured_output
+    parent = self()
+
+    owner =
+      spawn(fn ->
+        {:ok, workspace} = SchemaWorkspace.open(output)
+        {:ok, _guard} = WorkspaceGuard.start(workspace, self())
+        send(parent, {:guarded_workspace, workspace.directory})
+
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    assert_receive {:guarded_workspace, directory}
+    assert File.dir?(directory)
+    Process.exit(owner, :kill)
+    assert eventually(fn -> not File.exists?(directory) end)
+  end
+
+  test "managed cancellation removes the private workspace" do
+    before = workspace_directories()
+    waiting = %{Map.from_struct(request()) | prompt: "structured-wait"}
+
+    assert {:ok, run_id} = Run.start(:codex, waiting)
+    assert eventually(fn -> MapSet.size(MapSet.difference(workspace_directories(), before)) == 1 end)
+    assert :ok = Run.cancel(run_id)
+    assert {:ok, result} = Run.await(run_id, 5_000)
+    assert result.status == :cancelled
+    assert eventually(fn -> workspace_directories() == before end)
+  end
+
+  test "rejects an incompatible CLI before staging or starting a model run" do
+    before = workspace_directories()
+
+    request =
+      request()
+      |> Map.from_struct()
+      |> Map.put(:provider_options, %{cli_path: "incompatible-codex"})
+      |> RunRequest.new!()
+
+    context = %{
+      run_id: "compatibility-test",
+      run_owner: self(),
+      process_manager: IncompatibleProcessManager,
+      config: %{}
+    }
+
+    assert {:error,
+            %Error{
+              category: :configuration,
+              details: %{failure_kind: :incompatible_cli, minimum_version: "0.144.6"}
+            }} = Codex.run(request, context)
+
+    assert workspace_directories() == before
+  end
+
+  test "normalizes provider start failure and removes its staged workspace" do
+    before = workspace_directories()
+
+    request =
+      request()
+      |> Map.from_struct()
+      |> Map.put(:provider_options, %{cli_path: "compatible-but-unstartable"})
+      |> RunRequest.new!()
+
+    context = %{
+      run_id: "start-failure-test",
+      run_owner: self(),
+      process_manager: CompatibleStartFailureManager,
+      config: %{}
+    }
+
+    assert {:error, %Error{details: %{failure_kind: :provider_start_failed}}} = Codex.run(request, context)
+    assert workspace_directories() == before
+  end
+
+  test "provider crash and timeout are terminal failures with no retained workspace" do
+    before = workspace_directories()
+
+    crash = %{Map.from_struct(request()) | prompt: "structured-crash"}
+    assert {:ok, crash_result} = Jido.Harness.run(:codex, crash, await_timeout: 10_000)
+    assert crash_result.status == :failed
+    assert crash_result.error.details.failure_kind == "provider_execution_failed"
+    assert eventually(fn -> workspace_directories() == before end)
+
+    timeout = %{Map.from_struct(request()) | prompt: "structured-wait", runtime_timeout_ms: 1_000}
+    assert {:ok, timeout_result} = Jido.Harness.run(:codex, timeout, await_timeout: 10_000)
+    assert timeout_result.status == :failed
+    assert timeout_result.error.category == :timeout
+    assert eventually(fn -> workspace_directories() == before end)
+  end
+
+  test "readiness verifies cached subscription authentication without API-key fallback" do
+    fixture = Jido.Harness.TestHelpers.fixture_path("fake_stream_cli.exs")
+
+    assert {:ok, status} = Codex.status(%{cli_path: fixture})
+    assert status.installed
+    assert status.compatible
+    refute status.authenticated
+    refute status.smoke_ready
+    assert status.error == :cached_subscription_authentication_missing
+  end
+
+  test "cleanup failures are generic and path-free" do
+    workspace = %SchemaWorkspace{directory: <<0>>, schema_path: "private", working_directory: "private"}
+    assert {:error, %Error{details: %{failure_kind: :schema_staging_failed}} = error} = SchemaWorkspace.close(workspace)
+    refute inspect(error) =~ "private"
+  end
+
+  defp request do
+    RunRequest.new!(%{
+      prompt: "classify",
+      sandbox_mode: :read_only,
+      approval_mode: :auto_approve,
+      structured_output: %{schema_id: "hr.classification.v1", schema: @schema}
+    })
+  end
+
+  defp enumerate(events, output) do
+    {:ok, workspace} = SchemaWorkspace.open(output)
+    {:ok, guard} = WorkspaceGuard.start(workspace, self())
+    events |> Stream.wrap(output, guard) |> Enum.to_list()
+  end
+
+  defp final(text), do: Event.new!(provider: :codex, type: :output_text_final, payload: %{"text" => text})
+  defp completed, do: Event.new!(provider: :codex, type: :run_completed)
+
+  defp workspace_directories do
+    System.tmp_dir!()
+    |> Path.join("jido-harness-structured-output/run-*")
+    |> Path.wildcard()
+    |> MapSet.new()
+  end
+
+  defp pairs(argv, flag) do
+    argv
+    |> Enum.with_index()
+    |> Enum.flat_map(fn
+      {^flag, index} -> [Enum.at(argv, index + 1)]
+      _entry -> []
+    end)
+  end
+
+  defp eventually(function, attempts \\ 100)
+  defp eventually(function, 0), do: function.()
+
+  defp eventually(function, attempts) do
+    if function.() do
+      true
+    else
+      Process.sleep(10)
+      eventually(function, attempts - 1)
+    end
+  end
+
+  defp restore_env(name, nil), do: System.delete_env(name)
+  defp restore_env(name, value), do: System.put_env(name, value)
+end

--- a/test/jido_harness/structured_output_test.exs
+++ b/test/jido_harness/structured_output_test.exs
@@ -1,0 +1,119 @@
+defmodule Jido.Harness.StructuredOutputTest do
+  use ExUnit.Case, async: true
+
+  import Bitwise
+
+  alias Jido.Harness.{Error, JSONSchema, RequestResolver, RunRequest, StructuredOutput}
+  alias Jido.Harness.StructuredOutput.SchemaWorkspace
+
+  @schema %{
+    "type" => "object",
+    "properties" => %{
+      "department" => %{"type" => "string", "enum" => ["people", "finance"]},
+      "confidence" => %{"type" => "number", "minimum" => 0, "maximum" => 1}
+    },
+    "required" => ["department", "confidence"],
+    "additionalProperties" => false
+  }
+
+  test "admits a bounded normalized contract only for capable providers" do
+    attrs = %{prompt: "classify", structured_output: %{schema_id: "hr.classification.v1", schema: @schema}}
+
+    assert {:ok, %RunRequest{structured_output: %StructuredOutput{} = output}} =
+             RequestResolver.resolve(:codex, attrs)
+
+    assert output.schema_id == "hr.classification.v1"
+    assert output.max_output_bytes == 262_144
+
+    assert {:error, %Error{category: :validation, details: %{field: :structured_output}}} =
+             RequestResolver.resolve(:amp, attrs)
+  end
+
+  test "rejects invalid identifiers, output bounds, keywords, depth, and aggregate property counts" do
+    assert {:error, %Error{details: %{failure_kind: :invalid_schema_id}}} =
+             RunRequest.new(prompt: "x", structured_output: %{schema_id: "bad id", schema: @schema})
+
+    assert {:error, %Error{details: %{failure_kind: :invalid_output_limit}}} =
+             RunRequest.new(
+               prompt: "x",
+               structured_output: %{schema_id: "valid", schema: @schema, max_output_bytes: 1_048_577}
+             )
+
+    assert {:error, %Error{details: %{failure_kind: :unsupported_schema_keyword}}} =
+             JSONSchema.admit(%{"type" => "string", "pattern" => "private-value"})
+
+    too_deep =
+      Enum.reduce(1..17, %{"type" => "string"}, fn _index, child ->
+        %{"type" => "array", "items" => child}
+      end)
+
+    assert {:error, %Error{details: %{failure_kind: :schema_too_deep}}} = JSONSchema.admit(too_deep)
+
+    properties = Map.new(1..257, &{"field_#{&1}", %{"type" => "string"}})
+
+    assert {:error, %Error{details: %{failure_kind: :too_many_schema_properties}}} =
+             JSONSchema.admit(%{"type" => "object", "properties" => properties})
+  end
+
+  test "serializes schemas deterministically in an owner-only workspace and removes it" do
+    base = Path.join(System.tmp_dir!(), "jido-harness-schema-test-#{System.unique_integer([:positive])}")
+    output = StructuredOutput.new!(schema_id: "hr.v1", schema: @schema)
+
+    on_exit(fn -> File.rm_rf(base) end)
+
+    assert {:ok, expected} = JSONSchema.encode(@schema)
+    assert {:ok, workspace} = SchemaWorkspace.open(output, base_directory: base)
+    assert File.read!(workspace.schema_path) == expected
+    assert permissions(workspace.directory) == 0o700
+    assert permissions(workspace.schema_path) == 0o600
+    assert :ok = SchemaWorkspace.close(workspace)
+    refute File.exists?(workspace.directory)
+  end
+
+  test "uses unique workspaces and cleans up when the consumer raises" do
+    base = Path.join(System.tmp_dir!(), "jido-harness-schema-test-#{System.unique_integer([:positive])}")
+    output = StructuredOutput.new!(schema_id: "hr.v1", schema: @schema)
+    parent = self()
+
+    on_exit(fn -> File.rm_rf(base) end)
+
+    assert {:ok, first} = SchemaWorkspace.open(output, base_directory: base)
+    assert {:ok, second} = SchemaWorkspace.open(output, base_directory: base)
+    refute first.directory == second.directory
+    assert :ok = SchemaWorkspace.close(first)
+    assert :ok = SchemaWorkspace.close(second)
+
+    assert_raise RuntimeError, "consumer stopped", fn ->
+      SchemaWorkspace.with_open(
+        output,
+        fn workspace ->
+          send(parent, {:workspace, workspace.directory})
+          raise "consumer stopped"
+        end,
+        base_directory: base
+      )
+    end
+
+    assert_receive {:workspace, directory}
+    refute File.exists?(directory)
+  end
+
+  test "staging failures do not disclose schema data or paths" do
+    secret = "employee-secret-value"
+    output = StructuredOutput.new!(schema_id: "hr.v1", schema: %{"type" => "string", "const" => secret})
+    blocking_file = Path.join(System.tmp_dir!(), "schema-block-#{System.unique_integer([:positive])}")
+    blocked_base = Path.join(blocking_file, "blocked")
+    File.write!(blocking_file, "block")
+    on_exit(fn -> File.rm(blocking_file) end)
+
+    assert {:error, %Error{} = error} = SchemaWorkspace.open(output, base_directory: blocked_base)
+    rendered = inspect(error)
+    refute rendered =~ secret
+    refute rendered =~ blocked_base
+  end
+
+  defp permissions(path) do
+    {:ok, stat} = File.stat(path)
+    band(stat.mode, 0o777)
+  end
+end

--- a/test/jido_harness/structured_output_test.exs
+++ b/test/jido_harness/structured_output_test.exs
@@ -55,6 +55,37 @@ defmodule Jido.Harness.StructuredOutputTest do
              JSONSchema.admit(%{"type" => "object", "properties" => properties})
   end
 
+  test "admits the governed 128-concept schema within the bounded aggregate enum ceiling" do
+    concepts = Enum.map(1..128, &"concept-#{&1}")
+
+    schema = %{
+      "type" => "object",
+      "properties" => %{
+        "disposition" => %{"type" => "string", "enum" => ~w(classified insufficient ambiguous)},
+        "concept_id" => %{"type" => "string", "enum" => concepts}
+      },
+      "required" => ~w(disposition concept_id),
+      "additionalProperties" => false
+    }
+
+    assert :ok = JSONSchema.admit(schema)
+
+    too_many = %{"type" => "string", "enum" => Enum.map(1..257, &"value-#{&1}")}
+    assert {:error, %Error{details: %{failure_kind: :too_many_schema_enum_values}}} = JSONSchema.admit(too_many)
+  end
+
+  test "rejects schema combinators before provider execution" do
+    schema = %{
+      "anyOf" => [
+        %{"type" => "string"},
+        %{"type" => "null"}
+      ]
+    }
+
+    assert {:error, %Error{details: %{failure_kind: :unsupported_schema_keyword}}} =
+             JSONSchema.admit(schema)
+  end
+
   test "serializes schemas deterministically in an owner-only workspace and removes it" do
     base = Path.join(System.tmp_dir!(), "jido-harness-schema-test-#{System.unique_integer([:positive])}")
     output = StructuredOutput.new!(schema_id: "hr.v1", schema: @schema)

--- a/test/jido_harness/zoi_structs_test.exs
+++ b/test/jido_harness/zoi_structs_test.exs
@@ -20,6 +20,7 @@ defmodule Jido.Harness.ZoiStructsTest do
     SessionInfo,
     SessionRequest,
     SessionTransportSpec,
+    StructuredOutput,
     TextTail,
     TurnRequest,
     TurnResult
@@ -44,6 +45,7 @@ defmodule Jido.Harness.ZoiStructsTest do
     SessionInfo,
     SessionRequest,
     SessionTransportSpec,
+    StructuredOutput,
     TextTail,
     TurnRequest,
     TurnResult

--- a/test/support/fixtures/fake_stream_cli.exs
+++ b/test/support/fixtures/fake_stream_cli.exs
@@ -8,6 +8,13 @@ defmodule Jido.Harness.Fixture.StreamCLI do
       ~s("usage":{"input_tokens":2,"output_tokens":1}})
   ]
 
+  @codex_structured [
+    ~s({"type":"thread.started","thread_id":"codex-fixture-session"}),
+    ~s({"type":"item.completed","thread_id":"codex-fixture-session","item":{"type":"agent_message","text":"{\\"department\\":\\"people\\",\\"confidence\\":0.9}"}}),
+    ~s({"type":"turn.completed","thread_id":"codex-fixture-session","status":"completed",) <>
+      ~s("usage":{"input_tokens":2,"output_tokens":1}})
+  ]
+
   @gemini [
     ~s({"type":"init","session_id":"gemini-fixture-session","model":"fixture"}),
     ~s({"type":"message","role":"assistant","content":"gemini-ok","delta":true}),
@@ -43,6 +50,9 @@ defmodule Jido.Harness.Fixture.StreamCLI do
 
   def run(args) do
     cond do
+      args == ["--version"] -> IO.puts("codex-cli 0.144.6")
+      args == ["exec", "--help"] -> IO.puts("--output-schema --ephemeral --ignore-user-config --ignore-rules")
+      "exec" in args and "--json" in args and "--output-schema" in args -> structured(args)
       "exec" in args and "--json" in args -> emit(@codex)
       "--prompt" in args -> emit(@gemini)
       "--print" in args -> emit(@claude)
@@ -53,6 +63,22 @@ defmodule Jido.Harness.Fixture.StreamCLI do
   end
 
   defp emit(events), do: Enum.each(events, &IO.puts/1)
+
+  defp structured(args) do
+    required = ["--ephemeral", "--ignore-user-config", "--ignore-rules", "--output-schema"]
+    forbidden_env = Enum.any?(~w(OPENAI_API_KEY CODEX_API_KEY CODEX_ACCESS_TOKEN), &System.get_env/1)
+    isolated_cwd = Path.basename(File.cwd!()) == "workspace"
+
+    if Enum.all?(required, &(&1 in args)) and not forbidden_env and isolated_cwd do
+      case List.last(args) do
+        "structured-wait" -> Process.sleep(30_000)
+        "structured-crash" -> System.halt(7)
+        _prompt -> emit(@codex_structured)
+      end
+    else
+      emit([~s({"type":"turn.failed","error":{"message":"fixture isolation failed"}})])
+    end
+  end
 
   defp unsupported do
     IO.puts(:stderr, "unsupported fixture invocation")


### PR DESCRIPTION
## Summary\n- add bounded schema-constrained finite runs through cached Codex subscription auth\n- enforce ephemeral read-only isolation, cleanup, compatibility, and typed failures\n- accept Jido.Harness 2.1.0-rc.2 after live 128-concept schema validation\n\n## Verification\n- Compiling 91 files (.ex)
Generated jido_harness app
Running ExUnit with seed: 952618, max_cases: 40
Excluding tags: [:integration, :soak]

[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m
Finished in 22.3 seconds (1.1s async, 21.2s sync)
[32m133 tests, 0 failures (55 excluded)[0m
----------------
COV    FILE                                        LINES RELEVANT   MISSED
 68.1% lib/jido_harness.ex                           121       22        7
  0.0% lib/jido_harness/adapter.ex                    22        0        0
 67.6% lib/jido_harness/adapter_spec.ex              102       34       11
 65.9% lib/jido_harness/adapters/amp.ex              148       47       16
 66.6% lib/jido_harness/adapters/claude.ex           171       60       20
 76.4% lib/jido_harness/adapters/cli_args.ex          39       17        4
100.0% lib/jido_harness/adapters/cli_mapper.ex        26        5        0
 42.5% lib/jido_harness/adapters/cli_mapper/cla      152       40       23
 50.0% lib/jido_harness/adapters/cli_mapper/cod      162       42       21
 38.0% lib/jido_harness/adapters/cli_mapper/gem       99       21       13
 91.1% lib/jido_harness/adapters/cli_mapper/gro      148       45        4
 81.5% lib/jido_harness/adapters/cli_stream.ex       118       38        7
 82.9% lib/jido_harness/adapters/codex.ex            258       88       15
 88.8% lib/jido_harness/adapters/codex_compatib       89       27        3
100.0% lib/jido_harness/adapters/codex_environm       19        4        0
 66.6% lib/jido_harness/adapters/gemini.ex           136       45       15
 71.6% lib/jido_harness/adapters/grok.ex             175       53       15
 62.0% lib/jido_harness/adapters/helpers.ex          175       58       22
 66.1% lib/jido_harness/adapters/json_mapper.ex      142       59       20
 70.1% lib/jido_harness/adapters/kimi.ex             337       87       26
 52.7% lib/jido_harness/adapters/opencode.ex         160       36       17
 71.5% lib/jido_harness/adapters/pi.ex               521      116       33
 70.4% lib/jido_harness/adapters/zai.ex              202       61       18
100.0% lib/jido_harness/application.ex                22        2        0
 75.0% lib/jido_harness/await.ex                      27        8        2
 83.3% lib/jido_harness/buffer.ex                     43       12        2
 14.2% lib/jido_harness/capabilities.ex               48        7        6
 83.3% lib/jido_harness/cursor_stream.ex              52       18        3
 85.7% lib/jido_harness/error.ex                      58        7        1
 19.6% lib/jido_harness/escript.ex                   220       66       53
 88.0% lib/jido_harness/event.ex                     151       25        3
 57.8% lib/jido_harness/event_log.ex                  65       19        8
100.0% lib/jido_harness/id.ex                          9        2        0
 12.3% lib/jido_harness/integration_case.ex          569      138      121
 77.2% lib/jido_harness/journal.ex                   176       66       15
 70.3% lib/jido_harness/json_schema.ex               291      125       37
100.0% lib/jido_harness/process.ex                    65        7        0
  0.0% lib/jido_harness/process/driver.ex              8        0        0
 80.5% lib/jido_harness/process/driver/erlexec.       78       36        7
 73.3% lib/jido_harness/process/event.ex              65       15        4
 75.0% lib/jido_harness/process/info.ex               55        8        2
 86.6% lib/jido_harness/process/manager.ex           148       45        6
 66.6% lib/jido_harness/process/spec.ex              154       48       16
 89.0% lib/jido_harness/process/worker.ex            450      165       18
 90.0% lib/jido_harness/protocol/jsonl.ex             27       10        1
 60.0% lib/jido_harness/provider_status.ex            68       10        4
 95.2% lib/jido_harness/redaction.ex                  63       21        1
 63.1% lib/jido_harness/registry.ex                   80       19        7
 12.5% lib/jido_harness/retention.ex                  48       16       14
 96.1% lib/jido_harness/retention_options.ex          77       26        1
 66.6% lib/jido_harness/run.ex                       135       33       11
 50.0% lib/jido_harness/run/info.ex                   55        8        4
 83.7% lib/jido_harness/run/manager.ex               103       37        6
 90.0% lib/jido_harness/run/request.ex               178       40        4
 87.0% lib/jido_harness/run/request_resolver.ex      110       31        4
 42.8% lib/jido_harness/run/result.ex                 57        7        4
 83.1% lib/jido_harness/run/worker.ex                491      190       32
 59.3% lib/jido_harness/session.ex                   156       32       13
100.0% lib/jido_harness/session/active_turn.ex        21        1        0
 66.6% lib/jido_harness/session/adapter.ex            42        3        1
 64.2% lib/jido_harness/session/adapters/acp.ex       56       14        5
100.0% lib/jido_harness/session/adapters/manage       29        5        0
100.0% lib/jido_harness/session/adapters/pi_rpc       33        6        0
 44.4% lib/jido_harness/session/approval_respon       52        9        5
 88.4% lib/jido_harness/session/event_store.ex       137       52        6
 50.0% lib/jido_harness/session/info.ex               59        8        4
 75.0% lib/jido_harness/session/interaction_cap       61        8        2
 77.3% lib/jido_harness/session/lifecycle.ex         299      119       27
 71.5% lib/jido_harness/session/manager.ex           309      123       35
 57.8% lib/jido_harness/session/request.ex           162       38       16
 89.5% lib/jido_harness/session/request_validat      197       67        7
  0.0% lib/jido_harness/session/state.ex              51        0        0
 70.8% lib/jido_harness/session/timers.ex             64       24        7
 77.7% lib/jido_harness/session/transport_spec.       84        9        2
 64.6% lib/jido_harness/session/transports/acp.      465      178       63
 74.1% lib/jido_harness/session/transports/mana      213       89       23
 70.0% lib/jido_harness/session/transports/pi_r      278      100       30
 50.0% lib/jido_harness/session/turn_request.ex      128       38       19
 42.8% lib/jido_harness/session/turn_result.ex        58        7        4
 79.3% lib/jido_harness/session/worker.ex            433      165       34
 85.0% lib/jido_harness/structured_output.ex          84       20        3
 84.2% lib/jido_harness/structured_output/schem      110       38        6
 90.0% lib/jido_harness/structured_output/strea       99       30        3
 80.9% lib/jido_harness/structured_output/works       62       21        4
 93.7% lib/jido_harness/text_tail.ex                  58       16        1
 90.0% lib/jido_harness/validation.ex                 39       10        1
 85.7% lib/jido_harness/waiters.ex                    49       14        2
 73.8% lib/mix/tasks/jido_harness.chat.ex            129       42       11
 60.2% lib/mix/tasks/jido_harness.check.ex           161       68       27
 87.5% test/support/test_adapter.ex                  183       32        4
100.0% test/support/test_helpers.ex                   54       27        0
[TOTAL]  70.9%
----------------
Coverage data exported. (133 tests, 0 failures)\n- Checking 119 source files (this might take a while) ...

Please report incorrect results: https://github.com/rrrene/credo/issues

Analysis took 0.02 seconds (0.02s to load, 0.00s running 0 checks on 119 files)
1651 mods/funs, found no issues.

Showing priority issues: ↑ ↗ →  (use `mix credo explain` to explain issues, `mix credo --help` for options).
Finding suitable PLTs
Checking PLT...
[:asn1, :compiler, :crypto, :decimal, :eex, :elixir, :erlexec, :ex_unit, :excoveralls, :inets, :jason, :jido_harness, :kernel, :logger, :mix, :public_key, :ssl, :stdlib, :telemetry, :tools, :xmerl, :zoi]
PLT is up to date!
No :ignore_warnings opt specified in mix.exs and default does not exist.

Starting Dialyzer
[
  check_plt: false,
  init_plt: ~c"/home/ducky/code/metagraph/jido_harness/_build/dev/dialyxir_erlang-28.3.1_elixir-1.19.5_deps-dev.plt",
  files: [~c"/home/ducky/code/metagraph/jido_harness/_build/dev/lib/jido_harness/ebin/Elixir.Jido.Harness.Run.beam",
   ~c"/home/ducky/code/metagraph/jido_harness/_build/dev/lib/jido_harness/ebin/Elixir.Jido.Harness.ID.beam",
   ~c"/home/ducky/code/metagraph/jido_harness/_build/dev/lib/jido_harness/ebin/Elixir.Jido.Harness.SessionAdapters.ACP.beam",
   ~c"/home/ducky/code/metagraph/jido_harness/_build/dev/lib/jido_harness/ebin/Elixir.Jido.Harness.Protocol.JSONL.beam",
   ~c"/home/ducky/code/metagraph/jido_harness/_build/dev/lib/jido_harness/ebin/Elixir.Jido.Harness.Redaction.beam",
   ...],
  ...
]
Total errors: 0, Skipped: 0, Unnecessary Skips: 0
done in 0m3.03s
done (passed successfully)
Doctor file found. Loading configuration.
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Doc Cov  Spec Cov  Module                                   File                                                      Functions  No Docs  No Specs  Module Doc  Struct Spec
100%     100%      Jido.Harness                             lib/jido_harness.ex                                       8          0        0         Yes         N/A        
N/A      N/A       Jido.Harness.Adapter                     lib/jido_harness/adapter.ex                               0          0        0         Yes         N/A        
100%     100%      Jido.Harness.AdapterSpec                 lib/jido_harness/adapter_spec.ex                          3          0        0         Yes         Yes        
100%     100%      Jido.Harness.Adapters.Amp                lib/jido_harness/adapters/amp.ex                          6          0        0         Yes         N/A        
100%     100%      Jido.Harness.Adapters.Claude             lib/jido_harness/adapters/claude.ex                       6          0        0         Yes         N/A        
100%     100%      Jido.Harness.Adapters.CLIArgs            lib/jido_harness/adapters/cli_args.ex                     6          0        0         Yes         N/A        
100%     100%      Jido.Harness.Adapters.CLIMapper          lib/jido_harness/adapters/cli_mapper.ex                   5          0        0         Yes         N/A        
100%     100%      Jido.Harness.Adapters.CLIMapper.ClaudeS  lib/jido_harness/adapters/cli_mapper/claude_stream.ex     1          0        0         Yes         N/A        
100%     100%      Jido.Harness.Adapters.CLIMapper.Codex    lib/jido_harness/adapters/cli_mapper/codex.ex             1          0        0         Yes         N/A        
100%     100%      Jido.Harness.Adapters.CLIMapper.Gemini   lib/jido_harness/adapters/cli_mapper/gemini.ex            1          0        0         Yes         N/A        
100%     100%      Jido.Harness.Adapters.CLIMapper.Grok     lib/jido_harness/adapters/cli_mapper/grok.ex              1          0        0         Yes         N/A        
100%     100%      Jido.Harness.Adapters.Codex              lib/jido_harness/adapters/codex.ex                        6          0        0         Yes         N/A        
100%     100%      Jido.Harness.Adapters.CodexCompatibilit  lib/jido_harness/adapters/codex_compatibility.ex          2          0        0         Yes         N/A        
100%     100%      Jido.Harness.Adapters.CodexEnvironment   lib/jido_harness/adapters/codex_environment.ex            1          0        0         Yes         N/A        
100%     100%      Jido.Harness.Adapters.Gemini             lib/jido_harness/adapters/gemini.ex                       6          0        0         Yes         N/A        
100%     100%      Jido.Harness.Adapters.Grok               lib/jido_harness/adapters/grok.ex                         6          0        0         Yes         N/A        
100%     100%      Jido.Harness.Adapters.Kimi               lib/jido_harness/adapters/kimi.ex                         8          0        0         Yes         N/A        
100%     100%      Jido.Harness.Adapters.OpenCode           lib/jido_harness/adapters/opencode.ex                     6          0        0         Yes         N/A        
100%     100%      Jido.Harness.Adapters.Pi                 lib/jido_harness/adapters/pi.ex                           9          0        0         Yes         N/A        
100%     100%      Jido.Harness.Adapters.Zai                lib/jido_harness/adapters/zai.ex                          5          0        0         Yes         N/A        
100%     100%      Jido.Harness.Application                 lib/jido_harness/application.ex                           1          0        0         Yes         N/A        
100%     100%      Jido.Harness.Await                       lib/jido_harness/await.ex                                 1          0        0         Yes         N/A        
100%     100%      Jido.Harness.Capabilities                lib/jido_harness/capabilities.ex                          3          0        0         Yes         Yes        
100%     100%      Jido.Harness.Error                       lib/jido_harness/error.ex                                 5          0        0         Yes         N/A        
100%     100%      Jido.Harness.Escript                     lib/jido_harness/escript.ex                               1          0        0         Yes         N/A        
100%     70%       Jido.Harness.Event                       lib/jido_harness/event.ex                                 10         0        3         Yes         Yes        
100%     0%        Jido.Harness.IntegrationCase             lib/jido_harness/integration_case.ex                      14         0        14        Yes         N/A        
100%     100%      Jido.Harness.JSONSchema                  lib/jido_harness/json_schema.ex                           3          0        0         Yes         N/A        
100%     100%      Jido.Harness.Process                     lib/jido_harness/process.ex                               12         0        0         Yes         N/A        
N/A      N/A       Jido.Harness.ProcessDriver               lib/jido_harness/process/driver.ex                        0          0        0         Yes         N/A        
100%     100%      Jido.Harness.ProcessDriver.Erlexec       lib/jido_harness/process/driver/erlexec.ex                3          0        0         Yes         N/A        
100%     100%      Jido.Harness.ProcessEvent                lib/jido_harness/process/event.ex                         4          0        0         Yes         Yes        
100%     100%      Jido.Harness.ProcessInfo                 lib/jido_harness/process/info.ex                          4          0        0         Yes         Yes        
100%     8%        Jido.Harness.ProcessManager              lib/jido_harness/process/manager.ex                       13         0        12        Yes         N/A        
100%     100%      Jido.Harness.ProcessSpec                 lib/jido_harness/process/spec.ex                          4          0        0         Yes         Yes        
100%     80%       Jido.Harness.ProviderStatus              lib/jido_harness/provider_status.ex                       5          0        1         Yes         Yes        
100%     100%      Jido.Harness.Run                         lib/jido_harness/run.ex                                   10         0        0         Yes         N/A        
100%     100%      Jido.Harness.RunInfo                     lib/jido_harness/run/info.ex                              4          0        0         Yes         Yes        
100%     100%      Jido.Harness.RunRequest                  lib/jido_harness/run/request.ex                           3          0        0         Yes         Yes        
100%     100%      Jido.Harness.RunResult                   lib/jido_harness/run/result.ex                            3          0        0         Yes         Yes        
100%     100%      Jido.Harness.Session                     lib/jido_harness/session.ex                               15         0        0         Yes         N/A        
100%     100%      Jido.Harness.Session.ActiveTurn          lib/jido_harness/session/active_turn.ex                   1          0        0         Yes         Yes        
100%     100%      Jido.Harness.SessionAdapter              lib/jido_harness/session/adapter.ex                       2          0        0         Yes         N/A        
100%     100%      Jido.Harness.SessionAdapters.ACP         lib/jido_harness/session/adapters/acp.ex                  5          0        0         Yes         N/A        
100%     100%      Jido.Harness.SessionAdapters.Managed     lib/jido_harness/session/adapters/managed.ex              5          0        0         Yes         N/A        
100%     100%      Jido.Harness.SessionAdapters.PiRPC       lib/jido_harness/session/adapters/pi_rpc.ex               6          0        0         Yes         N/A        
100%     100%      Jido.Harness.ApprovalResponse            lib/jido_harness/session/approval_response.ex             3          0        0         Yes         Yes        
100%     100%      Jido.Harness.Session.EventStore          lib/jido_harness/session/event_store.ex                   5          0        0         Yes         N/A        
100%     100%      Jido.Harness.SessionInfo                 lib/jido_harness/session/info.ex                          4          0        0         Yes         Yes        
100%     100%      Jido.Harness.InteractionCapabilities     lib/jido_harness/session/interaction_capabilities.ex      4          0        0         Yes         Yes        
100%     100%      Jido.Harness.Session.Lifecycle           lib/jido_harness/session/lifecycle.ex                     6          0        0         Yes         N/A        
67%      0%        Jido.Harness.SessionRequest              lib/jido_harness/session/request.ex                       3          1        3         Yes         Yes        
100%     100%      Jido.Harness.Session.RequestValidator    lib/jido_harness/session/request_validator.ex             6          0        0         Yes         N/A        
N/A      N/A       Jido.Harness.Session.State               lib/jido_harness/session/state.ex                         0          0        0         Yes         Yes        
100%     100%      Jido.Harness.Session.Timers              lib/jido_harness/session/timers.ex                        7          0        0         Yes         N/A        
100%     75%       Jido.Harness.SessionTransportSpec        lib/jido_harness/session/transport_spec.ex                4          0        1         Yes         Yes        
83%      83%       Jido.Harness.SessionAdapters.ACPTranspo  lib/jido_harness/session/transports/acp.ex                6          1        1         Yes         N/A        
80%      80%       Jido.Harness.SessionAdapters.ManagedTra  lib/jido_harness/session/transports/managed.ex            5          1        1         Yes         N/A        
83%      83%       Jido.Harness.SessionAdapters.PiRPCTrans  lib/jido_harness/session/transports/pi_rpc.ex             6          1        1         Yes         N/A        
100%     100%      Jido.Harness.TurnRequest                 lib/jido_harness/session/turn_request.ex                  4          0        0         Yes         Yes        
100%     100%      Jido.Harness.TurnResult                  lib/jido_harness/session/turn_result.ex                   3          0        0         Yes         Yes        
86%      86%       Jido.Harness.SessionWorker               lib/jido_harness/session/worker.ex                        7          1        1         Yes         N/A        
100%     100%      Jido.Harness.StructuredOutput            lib/jido_harness/structured_output.ex                     4          0        0         Yes         Yes        
100%     100%      Jido.Harness.StructuredOutput.SchemaWor  lib/jido_harness/structured_output/schema_workspace.ex    3          0        0         Yes         Yes        
100%     100%      Jido.Harness.StructuredOutput.Stream     lib/jido_harness/structured_output/stream.ex              1          0        0         Yes         N/A        
100%     100%      Jido.Harness.StructuredOutput.Workspace  lib/jido_harness/structured_output/workspace_guard.ex     2          0        0         Yes         N/A        
100%     100%      Jido.Harness.Waiters                     lib/jido_harness/waiters.ex                               5          0        0         Yes         N/A        
100%     100%      Mix.Tasks.JidoHarness.Chat               lib/mix/tasks/jido_harness.chat.ex                        3          0        0         Yes         N/A        
100%     100%      Mix.Tasks.JidoHarness.Check              lib/mix/tasks/jido_harness.check.ex                       2          0        0         Yes         N/A        
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Summary:

Passed Modules: 69
Failed Modules: 0
Total Doc Coverage: 98.4%
Total Moduledoc Coverage: 100.0%
Total Spec Coverage: 88.0%

Doctor validation has passed!\n- deliberate cached-subscription smoke on Codex CLI 0.144.6