### PR TITLE
feat(codex): support xhigh reasoning effort

### DIFF
--- a/guides/providers.md
+++ b/guides/providers.md
@@ -100,7 +100,10 @@ mix jido_harness.check --providers codex --strict
 Common request concepts use normalized fields such as `model`,
 `provider_session_id`, `system_prompt`, `approval_mode`, `sandbox_mode`,
 `attachments`, and `reasoning_effort`. A provider accepts only the subset it
-declares.
+declares. Reasoning effort can be `low`, `medium`, `high`, or `xhigh`, but the
+adapter's `normalized_values` declaration limits the values for each provider.
+Codex and Grok accept `xhigh`; other built-in adapters retain their documented
+provider limits.
 
 Provider-specific escape hatches are nested:
 

--- a/lib/jido_harness/adapters/amp.ex
+++ b/lib/jido_harness/adapters/amp.ex
@@ -40,6 +40,7 @@ defmodule Jido.Harness.Adapters.Amp do
       default_session_transport: :stream_json_resume,
       session_transports: [Jido.Harness.SessionTransportSpec.managed(:stream_json_resume)],
       normalized_options: [:provider_session_id, :mcp_config, :reasoning_effort],
+      normalized_values: %{reasoning_effort: [nil, :low, :medium, :high]},
       provider_options: @provider_options,
       install: %{npm: "@sourcegraph/amp"}
     }

--- a/lib/jido_harness/adapters/claude.ex
+++ b/lib/jido_harness/adapters/claude.ex
@@ -45,6 +45,7 @@ defmodule Jido.Harness.Adapters.Claude do
         :sandbox_mode,
         :reasoning_effort
       ],
+      normalized_values: %{reasoning_effort: [nil, :low, :medium, :high]},
       provider_options: @provider_options,
       install: %{npm: "@anthropic-ai/claude-code"}
     }

--- a/lib/jido_harness/adapters/codex.ex
+++ b/lib/jido_harness/adapters/codex.ex
@@ -47,6 +47,7 @@ defmodule Jido.Harness.Adapters.Codex do
         :reasoning_effort,
         :structured_output
       ],
+      normalized_values: %{reasoning_effort: [nil, :low, :medium, :high, :xhigh]},
       provider_options: @provider_options,
       install: %{npm: "@openai/codex"}
     }

--- a/lib/jido_harness/adapters/grok.ex
+++ b/lib/jido_harness/adapters/grok.ex
@@ -63,6 +63,7 @@ defmodule Jido.Harness.Adapters.Grok do
         :sandbox_mode,
         :reasoning_effort
       ],
+      normalized_values: %{reasoning_effort: [nil, :low, :medium, :high, :xhigh]},
       provider_options: @provider_options,
       install: %{npm: "@xai-official/grok"}
     }

--- a/lib/jido_harness/adapters/kimi.ex
+++ b/lib/jido_harness/adapters/kimi.ex
@@ -73,7 +73,8 @@ defmodule Jido.Harness.Adapters.Kimi do
       ],
       normalized_values: %{
         approval_mode: [:default],
-        sandbox_mode: [:default]
+        sandbox_mode: [:default],
+        reasoning_effort: [nil, :low, :medium, :high]
       },
       provider_options: @provider_options,
       install: %{npm: "@moonshot-ai/kimi-code"}

--- a/lib/jido_harness/adapters/opencode.ex
+++ b/lib/jido_harness/adapters/opencode.ex
@@ -56,7 +56,10 @@ defmodule Jido.Harness.Adapters.OpenCode do
         }
       ],
       normalized_options: [:model, :provider_session_id, :approval_mode, :attachments, :reasoning_effort],
-      normalized_values: %{approval_mode: [:default, :prompt, :auto_approve]},
+      normalized_values: %{
+        approval_mode: [:default, :prompt, :auto_approve],
+        reasoning_effort: [nil, :low, :medium, :high]
+      },
       provider_options: @provider_options,
       install: %{npm: "opencode-ai"}
     }

--- a/lib/jido_harness/adapters/pi.ex
+++ b/lib/jido_harness/adapters/pi.ex
@@ -173,7 +173,8 @@ defmodule Jido.Harness.Adapters.Pi do
       ],
       normalized_values: %{
         approval_mode: [:default, :auto_approve],
-        sandbox_mode: [:default, :read_only, :unrestricted]
+        sandbox_mode: [:default, :read_only, :unrestricted],
+        reasoning_effort: [nil, :low, :medium, :high]
       },
       provider_options: @provider_options,
       install: %{npm: "@earendil-works/pi-coding-agent", npm_args: ["--ignore-scripts"]}

--- a/lib/jido_harness/adapters/zai.ex
+++ b/lib/jido_harness/adapters/zai.ex
@@ -54,6 +54,7 @@ defmodule Jido.Harness.Adapters.Zai do
         :sandbox_mode,
         :reasoning_effort
       ],
+      normalized_values: %{reasoning_effort: [nil, :low, :medium, :high]},
       provider_options: @provider_options,
       install: %{npm: "@anthropic-ai/claude-code"}
     }

--- a/lib/jido_harness/run/request.ex
+++ b/lib/jido_harness/run/request.ex
@@ -3,7 +3,7 @@ defmodule Jido.Harness.RunRequest do
 
   @approval_modes [:default, :prompt, :auto_edit, :auto_approve]
   @sandbox_modes [:default, :read_only, :workspace_write, :unrestricted]
-  @reasoning_efforts [:low, :medium, :high]
+  @reasoning_efforts [:low, :medium, :high, :xhigh]
   @keys [
     :prompt,
     :provider,

--- a/lib/jido_harness/session/request.ex
+++ b/lib/jido_harness/session/request.ex
@@ -3,7 +3,7 @@ defmodule Jido.Harness.SessionRequest do
 
   @approval_modes [:default, :prompt, :auto_edit, :auto_approve]
   @sandbox_modes [:default, :read_only, :workspace_write, :unrestricted]
-  @reasoning_efforts [:low, :medium, :high]
+  @reasoning_efforts [:low, :medium, :high, :xhigh]
   @keys [
     :provider,
     :cwd,

--- a/lib/jido_harness/session/turn_request.ex
+++ b/lib/jido_harness/session/turn_request.ex
@@ -1,7 +1,7 @@
 defmodule Jido.Harness.TurnRequest do
   @moduledoc "Validated input for one turn in an interactive session."
 
-  @reasoning_efforts [:low, :medium, :high]
+  @reasoning_efforts [:low, :medium, :high, :xhigh]
   @keys [:prompt, :content, :attachments, :reasoning_effort, :output_schema, :metadata, :provider_options]
 
   @schema Zoi.struct(

--- a/test/jido_harness/adapter_test.exs
+++ b/test/jido_harness/adapter_test.exs
@@ -108,6 +108,21 @@ defmodule Jido.Harness.AdapterTest do
     assert Enum.take(argv, -3) == ["resume", "thread-2", "codex"]
   end
 
+  test "Codex accepts xhigh and emits the exact reasoning configuration" do
+    assert {:ok, request} =
+             RequestResolver.resolve(:codex, %{prompt: "codex", reasoning_effort: :xhigh})
+
+    assert {:ok, argv} = Codex.build_argv(request, %{})
+    assert "model_reasoning_effort=\"xhigh\"" in pairs(argv, "--config")
+
+    assert {:error,
+            %Error{
+              category: :validation,
+              provider: :claude,
+              details: %{field: :reasoning_effort, value: :xhigh}
+            }} = RequestResolver.resolve(:claude, %{prompt: "claude", reasoning_effort: :xhigh})
+  end
+
   test "removed Codex SDK escape hatches are rejected" do
     assert {:error, %Error{category: :validation, details: %{key: :codex_options}}} =
              RequestResolver.resolve(:codex, %{prompt: "codex", provider_options: %{codex_options: %{}}})

--- a/test/jido_harness/run_request_test.exs
+++ b/test/jido_harness/run_request_test.exs
@@ -1,7 +1,18 @@
 defmodule Jido.Harness.RunRequestTest do
   use ExUnit.Case, async: true
 
-  alias Jido.Harness.{Error, RunRequest}
+  alias Jido.Harness.{Error, RunRequest, SessionRequest, TurnRequest}
+
+  test "accepts xhigh in finite, session, and turn request schemas" do
+    assert {:ok, %RunRequest{reasoning_effort: :xhigh}} =
+             RunRequest.new(prompt: "finite", reasoning_effort: :xhigh)
+
+    assert {:ok, %SessionRequest{reasoning_effort: :xhigh}} =
+             SessionRequest.new(reasoning_effort: :xhigh)
+
+    assert {:ok, %TurnRequest{reasoning_effort: :xhigh}} =
+             TurnRequest.new(prompt: "turn", reasoning_effort: :xhigh)
+  end
 
   test "normalizes string keys and validates the existing workspace" do
     assert {:ok, request} =

--- a/test/jido_harness/session_manager_test.exs
+++ b/test/jido_harness/session_manager_test.exs
@@ -100,6 +100,22 @@ defmodule Jido.Harness.SessionManagerTest do
     assert {:error, :not_found} = Jido.Harness.Session.info(session_id)
   end
 
+  test "accepts Codex xhigh sessions and rejects unsupported providers" do
+    assert {:ok, session_id} =
+             Jido.Harness.Session.start(:codex, %{reasoning_effort: :xhigh})
+
+    assert {:ok, %{state: :idle}} = await_idle(session_id)
+    assert :ok = Jido.Harness.Session.configure(session_id, %{reasoning_effort: :xhigh})
+    assert :ok = Jido.Harness.Session.close(session_id)
+    assert :ok = Jido.Harness.Session.prune(session_id)
+
+    assert {:error,
+            %Jido.Harness.Error{
+              provider: :claude,
+              details: %{field: :reasoning_effort, value: :xhigh}
+            }} = Jido.Harness.Session.start(:claude, %{reasoning_effort: :xhigh})
+  end
+
   test "rejects unsupported rich turn inputs before provider dispatch" do
     assert {:ok, session_id} = Jido.Harness.Session.start(:test)
     assert {:ok, _info} = await_idle(session_id)


### PR DESCRIPTION
## Summary

- add `xhigh` to finite-run, session, and turn request schemas
- allow `xhigh` for Codex and Grok while retaining existing limits for other built-in adapters
- verify Codex emits `model_reasoning_effort="xhigh"` and rejects the value for unsupported providers
- document provider-specific reasoning limits

## Validation

- `mix quality`
- `mix test` (136 passed, 55 excluded by the normal integration/soak filters)

Fixes #62